### PR TITLE
Set ForceNew for host_instance_type to true in order to enforce SDDC redeploy when host_instance_type is changed

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -18,8 +18,8 @@ data "vmc_customer_subnets" "my_subnets" {
 resource "vmc_sddc" "sddc_1" {
   sddc_name           = var.sddc_name
   vpc_cidr            = var.vpc_cidr
-  num_host            = 3
-  provider_type       = "AWS"
+  num_host            = var.num_hosts
+  provider_type       = var.provider_type
   region              = data.vmc_customer_subnets.my_subnets.region
   vxlan_subnet        = var.vxlan_subnet
   delay_account_link  = false
@@ -27,6 +27,10 @@ resource "vmc_sddc" "sddc_1" {
   sso_domain          = "vmc.local"
 
   deployment_type = "SingleAZ"
+
+  host_instance_type = var.host_instance_type
+
+  storage_capacity = var.storage_capacity
 
   account_link_sddc_config {
     customer_subnet_ids  = [data.vmc_customer_subnets.my_subnets.ids[0]]

--- a/examples/variables.tf
+++ b/examples/variables.tf
@@ -40,21 +40,21 @@ variable "public_ip_displayname" {
 
 
 variable host_instance_type {
-  description = "The instance type for the ESX hosts in the primary cluster of the SDDC"
-  default     = "I3_METAL"
+  description = "The instance type for the ESX hosts in the primary cluster of the SDDC. Possible values: I3_METAL, R5_METAL."
+  default     = ""
 }
 
 variable storage_capacity {
-  description = "The storage capacity value to be requested for the sddc primary cluster, in GiBs. If provided, instead of using the direct-attached storage, a capacity value amount of seperable storage will be used. Possible values for R5 metal are 15TB, 20TB, 25TB ,30TB, 35TB."
+  description = "The storage capacity value to be requested for the sddc primary cluster, in GiBs. If provided, instead of using the direct-attached storage, a capacity value amount of seperable storage will be used. Possible values for R5 metal are 15TB, 20TB, 25TB, 30TB, 35TB."
   default     = ""
 }
 
 variable num_hosts {
   description = "The number of hosts."
-  default     = "1"
+  default     = ""
 }
 
 variable provider_type {
   description = "Determines what additional properties are available based on cloud provider. Acceptable values are ZEROCLOUD and AWS with AWS as the default value."
-  default     = ""
+  default     = "AWS"
 }

--- a/examples/variables.tf
+++ b/examples/variables.tf
@@ -45,7 +45,7 @@ variable host_instance_type {
 }
 
 variable storage_capacity {
-  description = "Storage capacity"
+  description = "The storage capacity value to be requested for the sddc primary cluster, in GiBs. If provided, instead of using the direct-attached storage, a capacity value amount of seperable storage will be used. Possible values for R5 metal are 15TB, 20TB, 25TB ,30TB, 35TB."
   default     = ""
 }
 

--- a/examples/variables.tf
+++ b/examples/variables.tf
@@ -37,3 +37,24 @@ variable "public_ip_displayname" {
   description = "Display name for public IP."
   default     = "public-ip-test"
 }
+
+
+variable host_instance_type {
+  description = "The instance type for the ESX hosts in the primary cluster of the SDDC"
+  default     = "I3_METAL"
+}
+
+variable storage_capacity {
+  description = "Storage capacity"
+  default     = ""
+}
+
+variable num_hosts {
+  description = "The number of hosts."
+  default     = "1"
+}
+
+variable provider_type {
+  description = "Determines what additional properties are available based on cloud provider. Acceptable values are ZEROCLOUD and AWS with AWS as the default value."
+  default     = ""
+}

--- a/vmc/constants.go
+++ b/vmc/constants.go
@@ -13,6 +13,10 @@ const (
 	// sksNSXTManager to be stripped from nsxt reverse proxy url for public IP resource
 	SksNSXTManager string = "/sks-nsxt-manager"
 
+	// ESX Host instance types supported for SDDC creation.
+	HostInstancetypeI3  string ="I3_METAL"
+	HostInstancetypeR5  string ="R5_METAL"
+
 	// Env variables used in acceptance tests
 	APIToken            string = "API_TOKEN"
 	OrgID               string = "ORG_ID"

--- a/vmc/constants.go
+++ b/vmc/constants.go
@@ -14,8 +14,8 @@ const (
 	SksNSXTManager string = "/sks-nsxt-manager"
 
 	// ESX Host instance types supported for SDDC creation.
-	HostInstancetypeI3  string ="I3_METAL"
-	HostInstancetypeR5  string ="R5_METAL"
+	HostInstancetypeI3 string = "I3_METAL"
+	HostInstancetypeR5 string = "R5_METAL"
 
 	// Env variables used in acceptance tests
 	APIToken            string = "API_TOKEN"

--- a/vmc/resource_vmc_sddc.go
+++ b/vmc/resource_vmc_sddc.go
@@ -19,7 +19,7 @@ import (
 	"github.com/vmware/vsphere-automation-sdk-go/services/vmc/orgs/sddcs"
 )
 
-var storageCapacityMap = map[string]int{
+var storageCapacityMap = map[string]int64{
 	"15TB": 15003,
 	"20TB": 20004,
 	"25TB": 25005,
@@ -465,5 +465,5 @@ func getSDDC(connector client.Connector, orgID string, sddcID string) (model.Sdd
 
 func convertStorageCapacitytoInt(s string) int64 {
 	storageCapacity := storageCapacityMap[s]
-	return int64(storageCapacity)
+	return storageCapacity
 }

--- a/vmc/resource_vmc_sddc.go
+++ b/vmc/resource_vmc_sddc.go
@@ -108,6 +108,7 @@ func resourceSddc() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Default: "AWS",
 				ValidateFunc: validation.StringInSlice([]string{
 					"AWS", "ZEROCLOUD"}, false),
 			},
@@ -154,7 +155,7 @@ func resourceSddc() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice(
-					[]string{"I3_METAL", "R5_METAL"}, false),
+					[]string{HostInstancetypeI3, HostInstancetypeR5}, false),
 			},
 			"sddc_state": {
 				Type:     schema.TypeString,
@@ -183,28 +184,20 @@ func resourceSddc() *schema.Resource {
 
 			switch newInstanceType {
 
-			case "I3_METAL":
+			case HostInstancetypeI3:
 
 				if d.Get("storage_capacity").(string) != "" {
 
 					return fmt.Errorf("storage_capacity is not supported for host_instance_type %q", newInstanceType)
 
 				}
-			case "R5_METAL":
+			case HostInstancetypeR5:
 
 				if d.Get("storage_capacity").(string) == "" {
 
 					return fmt.Errorf("storage_capacity is required for host_instance_type %q", newInstanceType)
 
 				}
-
-			default:
-
-				// All other types support storage_capacity,
-
-				// so there is nothing to check.
-
-				return nil
 
 			}
 			return nil

--- a/vmc/resource_vmc_sddc.go
+++ b/vmc/resource_vmc_sddc.go
@@ -108,7 +108,7 @@ func resourceSddc() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
-				Default: "AWS",
+				Default:  "AWS",
 				ValidateFunc: validation.StringInSlice([]string{
 					"AWS", "ZEROCLOUD"}, false),
 			},

--- a/website/docs/r/sddc.html.markdown
+++ b/website/docs/r/sddc.html.markdown
@@ -68,7 +68,7 @@ The following arguments are supported:
 
 * `storage_capacity` - (Optional) The storage capacity value to be requested for the sddc primary cluster,
    in GiBs. If provided, instead of using the direct-attached storage, a capacity value amount of
-   separable storage will be used. Possible values for R5 metal are 15TB, 20TB, 25TB ,30TB, 35TB.
+   separable storage will be used. Possible values for R5 metal are 15TB, 20TB, 25TB, 30TB, 35TB.
 
 * `num_host` - (Required) The number of hosts.
 

--- a/website/docs/r/sddc.html.markdown
+++ b/website/docs/r/sddc.html.markdown
@@ -68,7 +68,7 @@ The following arguments are supported:
 
 * `storage_capacity` - (Optional) The storage capacity value to be requested for the sddc primary cluster,
    in GiBs. If provided, instead of using the direct-attached storage, a capacity value amount of
-   separable storage will be used.
+   separable storage will be used. Possible values for R5 metal are 15TB, 20TB, 25TB ,30TB, 35TB.
 
 * `num_host` - (Required) The number of hosts.
 


### PR DESCRIPTION
Modified code handle use case when the host_instance_type is changed. The SDDC should be deleted and a new one should be created when the host_instance_type is changes. This PR fixes the issue  https://github.com/vmware/terraform-provider-vmc/issues/47