### PR TITLE
Added check to store vxlan_subnet information in terraform state file only when skip_creating_vxlan = false

### DIFF
--- a/vmc/resource_vmc_sddc.go
+++ b/vmc/resource_vmc_sddc.go
@@ -416,8 +416,10 @@ func resourceSddcRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("provider_type", sddc.ResourceConfig.Provider)
 		d.Set("num_host", len(sddc.ResourceConfig.EsxHosts))
 		d.Set("vpc_cidr", *sddc.ResourceConfig.VpcInfo.VpcCidr)
-		d.Set("vxlan_subnet", sddc.ResourceConfig.VxlanSubnet)
-
+		skipCreatingVxLan := *sddc.ResourceConfig.SkipCreatingVxlan
+		if !skipCreatingVxLan {
+			d.Set("vxlan_subnet", sddc.ResourceConfig.VxlanSubnet)
+		}
 		sddcSizeInfo := map[string]string{}
 		sddcSizeInfo["vc_size"] = *sddc.ResourceConfig.SddcSize.VcSize
 		sddcSizeInfo["nsx_size"] = *sddc.ResourceConfig.SddcSize.NsxSize


### PR DESCRIPTION
The GET / POST SDDC API populates the vxlan_subnet with the default value when skip_creating_vxlan = true without actually creating a network segment.  Since this field is not provided in the configuration file while provisioning the SDDC, when a user does terraform apply the vxlan_subnet field (with ForceNew : true in schema) forces the SDDC resource to be destroyed and new one to be created. As a workaround for now, we are storing the vxlan_subnet only when skip_creating_vxlan = false since that is when the network segment is created.