### PR TITLE
Read intranet_mtu_uplink only for AWS provider type

### DIFF
--- a/vmc/resource_vmc_sddc.go
+++ b/vmc/resource_vmc_sddc.go
@@ -460,17 +460,20 @@ func resourceSddcRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("max_hosts", *edrsPolicy.MaxHosts)
 	d.Set("min_hosts", *edrsPolicy.MinHosts)
 
-	nsxtReverseProxyURL := d.Get("nsxt_reverse_proxy_url").(string)
-	connector, err = getNSXTReverseProxyURLConnector(nsxtReverseProxyURL)
-	if err != nil {
-		return HandleCreateError("NSXT reverse proxy URL connector", err)
+	if *sddc.Provider == AWSProviderType {
+		// store intranet_mtu_uplink only for AWS provider type
+		nsxtReverseProxyURL := d.Get("nsxt_reverse_proxy_url").(string)
+		connector, err = getNSXTReverseProxyURLConnector(nsxtReverseProxyURL)
+		if err != nil {
+			return HandleCreateError("NSXT reverse proxy URL connector", err)
+		}
+		cloudServicesCommonClient := nsxtawsintegrationapi.NewDefaultCloudServiceCommonClient(connector)
+		externalConnectivityConfig, err := cloudServicesCommonClient.GetExternalConnectivityConfig()
+		if err != nil {
+			return HandleReadError(d, "External connectivity configuration", sddcID, err)
+		}
+		d.Set("intranet_mtu_uplink", externalConnectivityConfig.IntranetMtu)
 	}
-	cloudServicesCommonClient := nsxtawsintegrationapi.NewDefaultCloudServiceCommonClient(connector)
-	externalConnectivityConfig, err := cloudServicesCommonClient.GetExternalConnectivityConfig()
-	if err != nil {
-		return HandleReadError(d, "External connectivity configuration", sddcID, err)
-	}
-	d.Set("intranet_mtu_uplink", externalConnectivityConfig.IntranetMtu)
 	return nil
 }
 

--- a/vmc/resource_vmc_sddc.go
+++ b/vmc/resource_vmc_sddc.go
@@ -460,8 +460,8 @@ func resourceSddcRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("max_hosts", *edrsPolicy.MaxHosts)
 	d.Set("min_hosts", *edrsPolicy.MinHosts)
 
-	if *sddc.Provider == AWSProviderType {
-		// store intranet_mtu_uplink only for AWS provider type
+	if *sddc.Provider != ZeroCloudProviderType {
+		// store intranet_mtu_uplink only non zerocloud provider types
 		nsxtReverseProxyURL := d.Get("nsxt_reverse_proxy_url").(string)
 		connector, err = getNSXTReverseProxyURLConnector(nsxtReverseProxyURL)
 		if err != nil {

--- a/vmc/resource_vmc_sddc.go
+++ b/vmc/resource_vmc_sddc.go
@@ -461,7 +461,7 @@ func resourceSddcRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("min_hosts", *edrsPolicy.MinHosts)
 
 	if *sddc.Provider != ZeroCloudProviderType {
-		// store intranet_mtu_uplink only non zerocloud provider types
+		// store intranet_mtu_uplink only for non zerocloud provider types
 		nsxtReverseProxyURL := d.Get("nsxt_reverse_proxy_url").(string)
 		connector, err = getNSXTReverseProxyURLConnector(nsxtReverseProxyURL)
 		if err != nil {


### PR DESCRIPTION
SDDC read post create for zero cloud is failing with error for NSX reverse proxy url. This url is not available for zero cloud provider types and needs to be read only for AWS provider type.