### PR TITLE
Fix for static check failures caused by references to deprecated functions

### DIFF
--- a/vmc/resource_vmc_cluster.go
+++ b/vmc/resource_vmc_cluster.go
@@ -193,7 +193,7 @@ func resourceClusterCreate(d *schema.ResourceData, m interface{}) error {
 		return HandleCreateError("Cluster", err)
 	}
 
-	return resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+	return resource.RetryContext(context.Background(), d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		tasksClient := orgs.NewDefaultTasksClient(connector)
 		task, err := tasksClient.Get(orgID, task.Id)
 		if err != nil {
@@ -293,7 +293,7 @@ func resourceClusterDelete(d *schema.ResourceData, m interface{}) error {
 		return HandleDeleteError("Cluster", clusterID, err)
 	}
 	tasksClient := orgs.NewDefaultTasksClient(connector)
-	return resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+	return resource.RetryContext(context.Background(), d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		task, err := tasksClient.Get(orgID, task.Id)
 		if err != nil {
 			return resource.NonRetryableError(fmt.Errorf("error deleting cluster %s : %v", clusterID, err))
@@ -340,7 +340,7 @@ func resourceClusterUpdate(d *schema.ResourceData, m interface{}) error {
 			return HandleUpdateError("Cluster", err)
 		}
 		tasksClient := orgs.NewDefaultTasksClient(connectorWrapper)
-		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+		err = resource.RetryContext(context.Background(), d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
 			task, err := tasksClient.Get(orgID, task.Id)
 			if err != nil {
 				return resource.NonRetryableError(fmt.Errorf("error updating hosts for cluster : %v", err))
@@ -375,7 +375,7 @@ func resourceClusterUpdate(d *schema.ResourceData, m interface{}) error {
 		if err != nil {
 			return HandleUpdateError("EDRS Policy", err)
 		}
-		return resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+		return resource.RetryContext(context.Background(), d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
 			taskClient := autoscalerapi.NewDefaultAutoscalerClient(connectorWrapper)
 			task, err := taskClient.Get(orgID, task.Id)
 			if err != nil {
@@ -405,7 +405,7 @@ func resourceClusterUpdate(d *schema.ResourceData, m interface{}) error {
 		if err != nil {
 			return HandleUpdateError("Microsoft Licensing Config", err)
 		}
-		return resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		return resource.RetryContext(context.Background(), d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 			tasksClient := orgs.NewDefaultTasksClient(connectorWrapper)
 			task, err := tasksClient.Get(orgID, task.Id)
 			if err != nil {

--- a/vmc/resource_vmc_sddc.go
+++ b/vmc/resource_vmc_sddc.go
@@ -32,7 +32,7 @@ func resourceSddc() *schema.Resource {
 		Update: resourceSddcUpdate,
 		Delete: resourceSddcDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(300 * time.Minute),
@@ -349,7 +349,7 @@ func resourceSddcCreate(d *schema.ResourceData, m interface{}) error {
 	// Wait until Sddc is created
 	sddcID := task.ResourceId
 	d.SetId(*sddcID)
-	return resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+	return resource.RetryContext(context.Background(), d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		tasksClient := orgs.NewDefaultTasksClient(connectorWrapper)
 		task, err := tasksClient.Get(orgID, task.Id)
 		if err != nil {
@@ -480,7 +480,7 @@ func resourceSddcDelete(d *schema.ResourceData, m interface{}) error {
 		return HandleDeleteError("SDDC", sddcID, err)
 	}
 	tasksClient := orgs.NewDefaultTasksClient(connector)
-	return resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+	return resource.RetryContext(context.Background(), d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		task, err := tasksClient.Get(orgID, task.Id)
 		if err != nil {
 			return resource.NonRetryableError(fmt.Errorf("error deleting SDDC %s: %v", sddcID, err))
@@ -526,7 +526,7 @@ func resourceSddcUpdate(d *schema.ResourceData, m interface{}) error {
 				if err != nil {
 					return HandleUpdateError("SDDC", err)
 				}
-				err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+				err = resource.RetryContext(context.Background(), d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
 					tasksClient := orgs.NewDefaultTasksClient(connectorWrapper)
 					task, err := tasksClient.Get(orgID, task.Id)
 
@@ -584,7 +584,7 @@ func resourceSddcUpdate(d *schema.ResourceData, m interface{}) error {
 			return HandleUpdateError("SDDC", err)
 		}
 		tasksClient := orgs.NewDefaultTasksClient(connectorWrapper)
-		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+		err = resource.RetryContext(context.Background(), d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
 			task, err := tasksClient.Get(orgID, task.Id)
 			if err != nil {
 				return resource.NonRetryableError(fmt.Errorf("error updating hosts : %v", err))
@@ -658,7 +658,7 @@ func resourceSddcUpdate(d *schema.ResourceData, m interface{}) error {
 			return HandleUpdateError("EDRS Policy", err)
 		}
 
-		return resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+		return resource.RetryContext(context.Background(), d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
 			taskClient := autoscalerapi.NewDefaultAutoscalerClient(connectorWrapper)
 			task, err := taskClient.Get(orgID, task.Id)
 			if err != nil {
@@ -699,7 +699,7 @@ func resourceSddcUpdate(d *schema.ResourceData, m interface{}) error {
 		if err != nil {
 			return fmt.Errorf("Error updating license : %s", err)
 		}
-		return resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		return resource.RetryContext(context.Background(), d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 			tasksClient := orgs.NewDefaultTasksClient(connectorWrapper)
 			task, err := tasksClient.Get(orgID, task.Id)
 			if err != nil || *task.Status == "FAILED" {

--- a/vmc/resource_vmc_srm_node.go
+++ b/vmc/resource_vmc_srm_node.go
@@ -4,6 +4,7 @@
 package vmc
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -92,7 +93,7 @@ func resourceSRMNodeCreate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	d.SetId(*task.ResourceId)
-	return resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+	return resource.RetryContext(context.Background(), d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		tasksClient := draas.NewDefaultTaskClient(connector)
 		task, err := tasksClient.Get(orgID, task.Id)
 		if err != nil {
@@ -157,7 +158,7 @@ func resourceSRMNodeDelete(d *schema.ResourceData, m interface{}) error {
 		return HandleDeleteError("SRM Node", sddcID, err)
 	}
 	tasksClient := draas.NewDefaultTaskClient(connector)
-	return resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+	return resource.RetryContext(context.Background(), d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		task, err := tasksClient.Get(orgID, task.Id)
 		if err != nil {
 			return resource.NonRetryableError(fmt.Errorf("error deleting SRM node for SDDC %s : %v", sddcID, err))


### PR DESCRIPTION
Replaced deprecated references of v1 sdk for resource.Retry and importstatepassthrough to resource.RetryContext and schema.ImportStatePassthroughContext in v2 sdk plugin.