### PR TITLE
Property "esx_hosts" in SddcResourceConfig is deprecated.

### DIFF
--- a/vmc/data_source_vmc_sddc.go
+++ b/vmc/data_source_vmc_sddc.go
@@ -150,7 +150,7 @@ func dataSourceVmcSddcRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("cloud_username", sddc.ResourceConfig.CloudUsername)
 		d.Set("nsxt_reverse_proxy_url", sddc.ResourceConfig.NsxApiPublicEndpointUrl)
 		d.Set("region", sddc.ResourceConfig.Region)
-		d.Set("num_host", len(sddc.ResourceConfig.EsxHosts))
+		d.Set("num_host", getTotalSddcHosts(&sddc))
 		d.Set("provider_type", sddc.ResourceConfig.Provider)
 		d.Set("availability_zones", sddc.ResourceConfig.AvailabilityZones)
 		d.Set("deployment_type", ConvertDeployType(*sddc.ResourceConfig.DeploymentType))

--- a/vmc/utils.go
+++ b/vmc/utils.go
@@ -88,3 +88,13 @@ func getNSXTReverseProxyURLConnector(nsxtReverseProxyUrl string) (client.Connect
 	}
 	return connector, nil
 }
+
+func getTotalSddcHosts(sddc *model.Sddc) int {
+	totalHosts := 0
+	if sddc != nil && sddc.ResourceConfig.Clusters != nil {
+		for _, cluster := range sddc.ResourceConfig.Clusters {
+			totalHosts += len(cluster.EsxHostList)
+		}
+	}
+	return totalHosts
+}


### PR DESCRIPTION
- Property "esx_hosts" in SddcResourceConfig is deprecated. fixed #112
- Restrict number of hosts update directly in SDDC's with multiple clusters.

Signed-off-by: Vandit Mehta <vmehta@vmware.com>