### PR TITLE
Bump VMC Bindings to version 0.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/vmware/vsphere-automation-sdk-go/lib v0.4.0
 	github.com/vmware/vsphere-automation-sdk-go/runtime v0.4.0
 	github.com/vmware/vsphere-automation-sdk-go/services/nsxt-vmc-aws-integration v0.5.0
-	github.com/vmware/vsphere-automation-sdk-go/services/vmc v0.7.0
+	github.com/vmware/vsphere-automation-sdk-go/services/vmc v0.8.0
 	github.com/vmware/vsphere-automation-sdk-go/services/vmc/autoscaler v0.4.0
 	github.com/vmware/vsphere-automation-sdk-go/services/vmc/draas v0.4.0
 	golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449 // indirect

--- a/go.sum
+++ b/go.sum
@@ -339,8 +339,8 @@ github.com/vmware/vsphere-automation-sdk-go/runtime v0.4.0 h1:SJI34JDj28bZyTI93k
 github.com/vmware/vsphere-automation-sdk-go/runtime v0.4.0/go.mod h1:GqC85noyNzapJN4vIAO9jJ1EKVo3+jCW4/2VTaMvuSg=
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt-vmc-aws-integration v0.5.0 h1:ouxD8KH9eISaFI6Jvda68T5IIdbIhzPNk7bLsRiMlyI=
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt-vmc-aws-integration v0.5.0/go.mod h1:AUU4ehco6CZoRUPP+k256nPqoSz/A1C4inhlvBMic+w=
-github.com/vmware/vsphere-automation-sdk-go/services/vmc v0.7.0 h1:SRY71QI85e2z/pq6ddj8KXU9FUUsuhu2OCSl5m4c6TA=
-github.com/vmware/vsphere-automation-sdk-go/services/vmc v0.7.0/go.mod h1:0v9QkzGaB+uzZMSfd4zbJueIwVpFQ/4+pEA/j6iKt4w=
+github.com/vmware/vsphere-automation-sdk-go/services/vmc v0.8.0 h1:b/ZlIM+Eg+wx9SYHOZmVwbzPBo99ZqAFxJxpCpVtk6Q=
+github.com/vmware/vsphere-automation-sdk-go/services/vmc v0.8.0/go.mod h1:0v9QkzGaB+uzZMSfd4zbJueIwVpFQ/4+pEA/j6iKt4w=
 github.com/vmware/vsphere-automation-sdk-go/services/vmc/autoscaler v0.4.0 h1:dFiOyd/QNLBVxz7WEacJ5oQgnX6sNS+IG8Sb9/L+5aE=
 github.com/vmware/vsphere-automation-sdk-go/services/vmc/autoscaler v0.4.0/go.mod h1:AsIpSwyWVatKxsPDrxaE/v78HZ13m7PuGpkmQkZw1Kk=
 github.com/vmware/vsphere-automation-sdk-go/services/vmc/draas v0.4.0 h1:X5EsaVkKsIBpLrVLQ8OqaBBfM1N7invFECpHdzzupYQ=


### PR DESCRIPTION
VMC team has released a hotfix to address issues [123](https://github.com/vmware/terraform-provider-vmc/issues/123) and [124](https://github.com/vmware/terraform-provider-vmc/issues/124). Version 0.8.0 of the VMC bindings has been released to accommodate these changes.

This change bumps the consumed VMC bindings by the VMC terraform provider to version 0.8.0.
