### PR TITLE
Fix nil dereference in resourceClusterRead 

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-/* Copyright 2019 VMware, Inc.
+/* Copyright 2019-2022 VMware, Inc.
    SPDX-License-Identifier: MPL-2.0 */
 
 package main

--- a/vmc/resource_vmc_cluster.go
+++ b/vmc/resource_vmc_cluster.go
@@ -1,4 +1,4 @@
-/* Copyright 2020 VMware, Inc.
+/* Copyright 2020-2022 VMware, Inc.
    SPDX-License-Identifier: MPL-2.0 */
 
 package vmc
@@ -264,8 +264,12 @@ func resourceClusterRead(d *schema.ResourceData, m interface{}) error {
 			cluster["cluster_state"] = *clusterConfig.ClusterState
 			cluster["host_instance_type"] = *clusterConfig.EsxHostInfo.InstanceType
 			if clusterConfig.MsftLicenseConfig != nil {
-				cluster["mssql_licensing"] = *clusterConfig.MsftLicenseConfig.MssqlLicensing
-				cluster["windows_licensing"] = *clusterConfig.MsftLicenseConfig.WindowsLicensing
+				if clusterConfig.MsftLicenseConfig.MssqlLicensing != nil {
+					cluster["mssql_licensing"] = *clusterConfig.MsftLicenseConfig.MssqlLicensing
+				}
+				if clusterConfig.MsftLicenseConfig.WindowsLicensing != nil {
+					cluster["windows_licensing"] = *clusterConfig.MsftLicenseConfig.WindowsLicensing
+				}
 			}
 			d.Set("cluster_info", cluster)
 			d.Set("num_hosts", len(clusterConfig.EsxHostList))

--- a/vmc/resource_vmc_sddc.go
+++ b/vmc/resource_vmc_sddc.go
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 VMware, Inc.
+/* Copyright 2019-2022 VMware, Inc.
    SPDX-License-Identifier: MPL-2.0 */
 
 package vmc


### PR DESCRIPTION
According to https://developer.vmware.com/apis/vmc/v1.1/data-structures/MsftLicensingConfig/

The primaryCluster.MsftLicenseConfig.MssqlLicensing and primaryCluster.MsftLicenseConfig.WindowsLicensing are optional, so a nil check is required before dereferencing.

Sanity tested apply, plan and destroy on DEV and PROD VMC.

https://github.com/vmware/terraform-provider-vmc/issues/139

Also updated some copyright headers.

Signed-off-by: Dimitar Proynov <proynovd@vmware.com>