### PR TITLE
Make SDDCs region property case-insensitive

### DIFF
--- a/vmc/data_source_vmc_customer_subnets.go
+++ b/vmc/data_source_vmc_customer_subnets.go
@@ -1,4 +1,4 @@
-/* Copyright 2019 VMware, Inc.
+/* Copyright 2019-2022 VMware, Inc.
    SPDX-License-Identifier: MPL-2.0 */
 
 package vmc
@@ -6,6 +6,7 @@ package vmc
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -29,6 +30,9 @@ func dataSourceVmcCustomerSubnets() *schema.Resource {
 				ValidateFunc: validation.All(
 					validation.NoZeroValues,
 				),
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return old == strings.ReplaceAll(strings.ToUpper(new), "-", "_")
+				},
 			},
 			"num_hosts": {
 				Type:        schema.TypeInt,

--- a/vmc/resource_vmc_sddc.go
+++ b/vmc/resource_vmc_sddc.go
@@ -146,6 +146,9 @@ func resourceSddc() *schema.Resource {
 				ValidateFunc: validation.All(
 					validation.NoZeroValues,
 				),
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return old == strings.ReplaceAll(strings.ToUpper(new), "-", "_")
+				},
 			},
 			"cluster_id": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
A small enhancement, improving user experience.

The change was proposed by Gilles Chekroun.
After the change "terraform plan" doesn't mention that SDDC should be redeployed because "US_WEST_2" is different from "us-west-2".

"make test" passed.

Signed-off-by: Dimitar Proynov <proynovd@vmware.com>