### PR TITLE
Introduce support for the new "i4i.metal" AWS host instance type

### DIFF
--- a/examples/cluster/variables.tf
+++ b/examples/cluster/variables.tf
@@ -39,12 +39,7 @@ variable provider_type {
 }
 
 variable host_instance_type {
-  description = "The instance type for the ESX hosts in the primary cluster of the SDDC. Possible values: I3_METAL, R5_METAL."
-  default     = ""
-}
-
-variable storage_capacity {
-  description = "The storage capacity value to be requested for the SDDC primary cluster. This variable is only for R5.METAL. Possible values are 15TB, 20TB, 25TB, 30TB, 35TB per host."
+  description = "The instance type for the ESX hosts in the primary cluster of the SDDC. Possible values: I3_METAL, I4I_METAL."
   default     = ""
 }
 

--- a/examples/public_ip/variables.tf
+++ b/examples/public_ip/variables.tf
@@ -43,12 +43,7 @@ variable sddc_type {
   default = "1NODE"
 }
 variable host_instance_type {
-  description = "The instance type for the ESX hosts in the primary cluster of the SDDC. Possible values: I3_METAL, R5_METAL."
-  default     = ""
-}
-
-variable storage_capacity {
-  description = "The storage capacity value to be requested for the SDDC primary cluster. This variable is only for R5.METAL. Possible values are 15TB, 20TB, 25TB, 30TB, 35TB per host."
+  description = "The instance type for the ESX hosts in the primary cluster of the SDDC. Possible values: I3_METAL, I4I_METAL."
   default     = ""
 }
 

--- a/examples/sddc/variables.tf
+++ b/examples/sddc/variables.tf
@@ -34,12 +34,7 @@ variable "vxlan_subnet" {
 }
 
 variable host_instance_type {
-  description = "The instance type for the ESX hosts in the primary cluster of the SDDC. Possible values: I3_METAL, R5_METAL."
-  default     = ""
-}
-
-variable storage_capacity {
-  description = "The storage capacity value to be requested for the SDDC primary cluster. This variable is only for R5.METAL. Possible values are 15TB, 20TB, 25TB, 30TB, 35TB per host."
+  description = "The instance type for the ESX hosts in the primary cluster of the SDDC. Possible values: I3_METAL, I4I_METAL."
   default     = ""
 }
 

--- a/examples/site_recovery/variables.tf
+++ b/examples/site_recovery/variables.tf
@@ -43,12 +43,7 @@ variable sddc_type {
   default = "1NODE"
 }
 variable host_instance_type {
-  description = "The instance type for the ESX hosts in the primary cluster of the SDDC. Possible values: I3_METAL, R5_METAL."
-  default     = ""
-}
-
-variable storage_capacity {
-  description = "The storage capacity value to be requested for the SDDC primary cluster. This variable is only for R5.METAL. Possible values are 15TB, 20TB, 25TB, 30TB, 35TB per host."
+  description = "The instance type for the ESX hosts in the primary cluster of the SDDC. Possible values: I3_METAL, I4I_METAL."
   default     = ""
 }
 

--- a/examples/srm_node/variables.tf
+++ b/examples/srm_node/variables.tf
@@ -34,12 +34,7 @@ variable "vxlan_subnet" {
 }
 
 variable host_instance_type {
-  description = "The instance type for the ESX hosts in the primary cluster of the SDDC. Possible values: I3_METAL, R5_METAL."
-  default     = ""
-}
-
-variable storage_capacity {
-  description = "The storage capacity value to be requested for the SDDC primary cluster. This variable is only for R5.METAL. Possible values are 15TB, 20TB, 25TB, 30TB, 35TB per host."
+  description = "The instance type for the ESX hosts in the primary cluster of the SDDC. Possible values: I3_METAL, I4I_METAL."
   default     = ""
 }
 

--- a/examples/stretched_cluster/variables.tf
+++ b/examples/stretched_cluster/variables.tf
@@ -34,12 +34,7 @@ variable "vxlan_subnet" {
 }
 
 variable host_instance_type {
-  description = "The instance type for the ESX hosts in the primary cluster of the SDDC. Possible values: I3_METAL, R5_METAL."
-  default     = ""
-}
-
-variable storage_capacity {
-  description = "The storage capacity value to be requested for the SDDC primary cluster. This variable is only for R5.METAL. Possible values are 15TB, 20TB, 25TB, 30TB, 35TB per host."
+  description = "The instance type for the ESX hosts in the primary cluster of the SDDC. Possible values: I3_METAL, I4I_METAL."
   default     = ""
 }
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/vmware/vsphere-automation-sdk-go/lib v0.4.0
 	github.com/vmware/vsphere-automation-sdk-go/runtime v0.4.0
 	github.com/vmware/vsphere-automation-sdk-go/services/nsxt-vmc-aws-integration v0.5.0
-	github.com/vmware/vsphere-automation-sdk-go/services/vmc v0.8.0
+	github.com/vmware/vsphere-automation-sdk-go/services/vmc v0.9.0
 	github.com/vmware/vsphere-automation-sdk-go/services/vmc/autoscaler v0.4.0
 	github.com/vmware/vsphere-automation-sdk-go/services/vmc/draas v0.4.0
 	google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d // indirect

--- a/go.sum
+++ b/go.sum
@@ -233,8 +233,8 @@ github.com/vmware/vsphere-automation-sdk-go/runtime v0.4.0 h1:SJI34JDj28bZyTI93k
 github.com/vmware/vsphere-automation-sdk-go/runtime v0.4.0/go.mod h1:GqC85noyNzapJN4vIAO9jJ1EKVo3+jCW4/2VTaMvuSg=
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt-vmc-aws-integration v0.5.0 h1:ouxD8KH9eISaFI6Jvda68T5IIdbIhzPNk7bLsRiMlyI=
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt-vmc-aws-integration v0.5.0/go.mod h1:AUU4ehco6CZoRUPP+k256nPqoSz/A1C4inhlvBMic+w=
-github.com/vmware/vsphere-automation-sdk-go/services/vmc v0.8.0 h1:b/ZlIM+Eg+wx9SYHOZmVwbzPBo99ZqAFxJxpCpVtk6Q=
-github.com/vmware/vsphere-automation-sdk-go/services/vmc v0.8.0/go.mod h1:0v9QkzGaB+uzZMSfd4zbJueIwVpFQ/4+pEA/j6iKt4w=
+github.com/vmware/vsphere-automation-sdk-go/services/vmc v0.9.0 h1:F2x4GaeppSRVICidPjRsZ3zKs8uGWIPu0OyuMb5TVQQ=
+github.com/vmware/vsphere-automation-sdk-go/services/vmc v0.9.0/go.mod h1:0v9QkzGaB+uzZMSfd4zbJueIwVpFQ/4+pEA/j6iKt4w=
 github.com/vmware/vsphere-automation-sdk-go/services/vmc/autoscaler v0.4.0 h1:dFiOyd/QNLBVxz7WEacJ5oQgnX6sNS+IG8Sb9/L+5aE=
 github.com/vmware/vsphere-automation-sdk-go/services/vmc/autoscaler v0.4.0/go.mod h1:AsIpSwyWVatKxsPDrxaE/v78HZ13m7PuGpkmQkZw1Kk=
 github.com/vmware/vsphere-automation-sdk-go/services/vmc/draas v0.4.0 h1:X5EsaVkKsIBpLrVLQ8OqaBBfM1N7invFECpHdzzupYQ=

--- a/vmc/constants.go
+++ b/vmc/constants.go
@@ -20,6 +20,7 @@ const (
 	HostInstancetypeI3   string = "I3_METAL"
 	HostInstancetypeR5   string = "R5_METAL"
 	HostInstancetypeI3EN string = "I3EN_METAL"
+	HostInstancetypeI4I  string = "I4I_METAL"
 
 	// Availability Zones
 	SingleAvailabilityZone string = "SingleAZ"

--- a/vmc/resource_vmc_cluster.go
+++ b/vmc/resource_vmc_cluster.go
@@ -74,7 +74,7 @@ func resourceCluster() *schema.Resource {
 				Optional:    true,
 				Description: "The instance type for the esx hosts added to this cluster.",
 				ValidateFunc: validation.StringInSlice(
-					[]string{HostInstancetypeI3, HostInstancetypeR5, HostInstancetypeI3EN}, false),
+					[]string{HostInstancetypeI3, HostInstancetypeR5, HostInstancetypeI3EN, HostInstancetypeI4I}, false),
 			},
 			"storage_capacity": {
 				Type:     schema.TypeString,
@@ -144,7 +144,7 @@ func resourceCluster() *schema.Resource {
 
 			switch newInstanceType {
 
-			case HostInstancetypeI3, HostInstancetypeI3EN:
+			case HostInstancetypeI3, HostInstancetypeI3EN, HostInstancetypeI4I:
 
 				if d.Get("storage_capacity").(string) != "" {
 
@@ -155,7 +155,8 @@ func resourceCluster() *schema.Resource {
 
 				if d.Get("storage_capacity").(string) == "" {
 
-					return fmt.Errorf("storage_capacity is required for host_instance_type %q", newInstanceType)
+					return fmt.Errorf("storage_capacity is required for host_instance_type %q "+
+						"Possible values are 15TB, 20TB, 25TB, 30TB, 35TB per host", newInstanceType)
 
 				}
 
@@ -174,7 +175,7 @@ func resourceClusterCreate(d *schema.ResourceData, m interface{}) error {
 	connector := m.(*ConnectorWrapper)
 	orgID := m.(*ConnectorWrapper).OrgID
 	clusterClient := sddcs.NewClustersClient(connector)
-	hostInstanceType := model.HostInstanceTypesEnum(d.Get("host_instance_type").(string))
+	hostInstanceType := getHostInstanceType(d)
 	storageCapacity := d.Get("storage_capacity").(string)
 	if len(strings.TrimSpace(storageCapacity)) > 0 {
 		storageCapacityConverted = ConvertStorageCapacitytoInt(storageCapacity)

--- a/vmc/resource_vmc_sddc.go
+++ b/vmc/resource_vmc_sddc.go
@@ -159,7 +159,7 @@ func resourceSddc() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice(
-					[]string{HostInstancetypeI3, HostInstancetypeR5, HostInstancetypeI3EN}, false),
+					[]string{HostInstancetypeI3, HostInstancetypeR5, HostInstancetypeI3EN, HostInstancetypeI4I}, false),
 			},
 			"edrs_policy_type": {
 				Type:     schema.TypeString,
@@ -294,13 +294,14 @@ func resourceSddc() *schema.Resource {
 
 			newInstanceType := d.Get("host_instance_type").(string)
 			switch newInstanceType {
-			case HostInstancetypeI3, HostInstancetypeI3EN:
+			case HostInstancetypeI3, HostInstancetypeI3EN, HostInstancetypeI4I:
 				if d.Get("storage_capacity").(string) != "" {
 					return fmt.Errorf("storage_capacity is not supported for host_instance_type %q", newInstanceType)
 				}
 			case HostInstancetypeR5:
 				if d.Get("storage_capacity").(string) == "" {
-					return fmt.Errorf("storage_capacity is required for host_instance_type %q", newInstanceType)
+					return fmt.Errorf("storage_capacity is required for host_instance_type %q."+
+						" Possible values are 15TB, 20TB, 25TB, 30TB, 35TB per host", newInstanceType)
 				}
 			}
 			return nil
@@ -355,7 +356,7 @@ func resourceSddcCreate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	accountLinkSddcConfig := expandAccountLinkSddcConfig(accountLinkSddcConfigVar)
-	hostInstanceType := model.HostInstanceTypesEnum(d.Get("host_instance_type").(string))
+	hostInstanceType := getHostInstanceType(d)
 	msftLicensingConfig := expandMsftLicenseConfig(d.Get("microsoft_licensing_config").([]interface{}))
 
 	var awsSddcConfig = &model.AwsSddcConfig{

--- a/vmc/utils.go
+++ b/vmc/utils.go
@@ -5,6 +5,7 @@ package vmc
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"net/http"
 	"net/url"
 	"os"
@@ -97,4 +98,16 @@ func getTotalSddcHosts(sddc *model.Sddc) int {
 		}
 	}
 	return totalHosts
+}
+
+// getHostInstanceType corrects for a deficiency in the GO SDK the string value "I4I_METAL"
+// is sent on the wire, which is not recognised by the VMC service as a valid host instance type.
+// This method replaces it with the string value of "i4i.metal" which is recognised by the VMC service.
+func getHostInstanceType(d *schema.ResourceData) model.HostInstanceTypesEnum {
+	var hostInstanceTypeStringValue = d.Get("host_instance_type").(string)
+	if hostInstanceTypeStringValue == HostInstancetypeI4I {
+		//The following value is recognised by the VMC service
+		hostInstanceTypeStringValue = "i4i.metal"
+	}
+	return model.HostInstanceTypesEnum(hostInstanceTypeStringValue)
 }


### PR DESCRIPTION
Due to a deficiency in the GO SDK the string value  "I4I_METAL" is sent on the wire, which is not recognised by the
VMC service as a valid host instance type. Thus a bit of hacking is required until the issue with the
GO SDK is fixed.

Additionally, removed references to the R5 host instance type from the documentation, due to a shortage of these
hosts in AWS. The code that concerns them is left to enable users to manage their already deployed instances.

The documentation change also fixes:
https://github.com/vmware/terraform-provider-vmc/issues/128

Testing done:
Successfully deployed a single-host i4i.metal SDDC
Successfully destroyed a single-host i4i.metal SDDC

Successfully deployed a single-host i3i.metal SDDC
Successfully destroyed a single-host i3i.metal SDDC

golangci-lint run - passed

Signed-off-by: Dimitar Proynov <proynovd@vmware.com>