### PR TITLE
Introduce lightweight E2E test for SDDC resource, using the ZEROCLOUD…

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,6 +10,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.45.2
+          version: v1.49.0
           args: --issues-exit-code=1
           only-new-issues: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,12 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.4
+          go-version: 1.19.1
       -
         name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.45.2
+          version: v1.49.0
           args: --issues-exit-code=1
       -
         name: Import GPG key

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,17 +5,14 @@ issues:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - errcheck
     - gofmt
     - gosimple
     - ineffassign
     - misspell
     - staticcheck
-    - structcheck
     - unconvert
     - unused
-    - varcheck
     - vet
 
 linters-settings:

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,9 @@
 module github.com/vmware/terraform-provider-vmc
 
-go 1.16
+go 1.19
 
 require (
-	github.com/agext/levenshtein v1.2.3 // indirect
-	github.com/fatih/color v1.9.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.11.0
-	github.com/hashicorp/yamux v0.0.0-20200609203250-aecfd211c9ce // indirect
-	github.com/mattn/go-colorable v0.1.7 // indirect
-	github.com/oklog/run v1.1.0 // indirect
 	github.com/satori/go.uuid v1.2.0
 	github.com/stretchr/testify v1.7.1
 	github.com/vmware/vsphere-automation-sdk-go/lib v0.4.0
@@ -17,6 +12,58 @@ require (
 	github.com/vmware/vsphere-automation-sdk-go/services/vmc v0.10.0
 	github.com/vmware/vsphere-automation-sdk-go/services/vmc/autoscaler v0.4.0
 	github.com/vmware/vsphere-automation-sdk-go/services/vmc/draas v0.4.0
+)
+
+require (
+	github.com/agext/levenshtein v1.2.3 // indirect
+	github.com/apparentlymart/go-cidr v1.1.0 // indirect
+	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
+	github.com/beevik/etree v1.1.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fatih/color v1.9.0 // indirect
+	github.com/gibson042/canonicaljson-go v1.0.3 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.7 // indirect
+	github.com/google/uuid v1.2.0 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 // indirect
+	github.com/hashicorp/go-hclog v1.2.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/go-plugin v1.4.3 // indirect
+	github.com/hashicorp/go-uuid v1.0.2 // indirect
+	github.com/hashicorp/go-version v1.4.0 // indirect
+	github.com/hashicorp/hc-install v0.3.1 // indirect
+	github.com/hashicorp/hcl/v2 v2.11.1 // indirect
+	github.com/hashicorp/logutils v1.0.0 // indirect
+	github.com/hashicorp/terraform-exec v0.16.0 // indirect
+	github.com/hashicorp/terraform-json v0.13.0 // indirect
+	github.com/hashicorp/terraform-plugin-go v0.8.0 // indirect
+	github.com/hashicorp/terraform-plugin-log v0.3.0 // indirect
+	github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896 // indirect
+	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 // indirect
+	github.com/hashicorp/yamux v0.0.0-20200609203250-aecfd211c9ce // indirect
+	github.com/mattn/go-colorable v0.1.7 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/mitchellh/mapstructure v1.4.3 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/oklog/run v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
+	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
+	github.com/vmihailenco/tagparser v0.1.1 // indirect
+	github.com/zclconf/go-cty v1.10.0 // indirect
+	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e // indirect
+	golang.org/x/net v0.0.0-20210510120150-4163338589ed // indirect
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
+	golang.org/x/text v0.3.6 // indirect
+	google.golang.org/appengine v1.6.6 // indirect
 	google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d // indirect
+	google.golang.org/grpc v1.45.0 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -10,12 +10,13 @@ require (
 	github.com/mattn/go-colorable v0.1.7 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/satori/go.uuid v1.2.0
-	github.com/stretchr/testify v1.7.0
+	github.com/stretchr/testify v1.7.1
 	github.com/vmware/vsphere-automation-sdk-go/lib v0.4.0
 	github.com/vmware/vsphere-automation-sdk-go/runtime v0.4.0
 	github.com/vmware/vsphere-automation-sdk-go/services/nsxt-vmc-aws-integration v0.5.0
 	github.com/vmware/vsphere-automation-sdk-go/services/vmc v0.10.0
 	github.com/vmware/vsphere-automation-sdk-go/services/vmc/autoscaler v0.4.0
 	github.com/vmware/vsphere-automation-sdk-go/services/vmc/draas v0.4.0
+	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 	google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -20,7 +20,6 @@ github.com/apparentlymart/go-cidr v1.1.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/Y
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
 github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0 h1:MzVXffFUye+ZcSR6opIgz9Co7WcDx6ZcY+RjfFHoA0I=
 github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
-github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2wFoYVvnCs0=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,9 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
@@ -310,8 +311,9 @@ golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210502180810-71e4cd670f79/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/vmc/clientconnector.go
+++ b/vmc/clientconnector.go
@@ -23,7 +23,7 @@ func NewClientConnectorByRefreshToken(refreshToken, serviceUrl, cspURL string,
 	httpClient http.Client) (client.Connector, error) {
 
 	if len(serviceUrl) <= 0 {
-		serviceUrl = DefaultVMCServer
+		serviceUrl = DefaultVMCUrl
 	}
 
 	if len(cspURL) <= 0 {

--- a/vmc/clientconnector.go
+++ b/vmc/clientconnector.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -60,7 +60,7 @@ func SecurityContextByRefreshToken(refreshToken string, cspURL string) (core.Sec
 	}
 
 	if res.StatusCode != 200 {
-		b, _ := ioutil.ReadAll(res.Body)
+		b, _ := io.ReadAll(res.Body)
 		return nil, fmt.Errorf("response from Cloud Service Provider contains status code %d : %s", res.StatusCode, string(b))
 	}
 

--- a/vmc/constants.go
+++ b/vmc/constants.go
@@ -4,8 +4,8 @@
 package vmc
 
 const (
-	// DefaultVMCServer defines the default VMC server.
-	DefaultVMCServer string = "https://vmc.vmware.com"
+	// DefaultVMCUrl defines the default VMC server url.
+	DefaultVMCUrl string = "https://vmc.vmware.com"
 
 	// DefaultCSPUrl defines the default URL for CSP.
 	DefaultCSPUrl string = "https://console.cloud.vmware.com"
@@ -65,10 +65,14 @@ const (
 	MaxHosts = 16
 
 	// Env variables used in acceptance tests
-	APIToken            string = "API_TOKEN"
-	OrgID               string = "ORG_ID"
-	OrgDisplayName      string = "ORG_DISPLAY_NAME"
-	TestSDDCId          string = "TEST_SDDC_ID"
+	VMCUrl         string = "VMC_URL"
+	CSPUrl         string = "CSP_URL"
+	APIToken       string = "API_TOKEN"
+	OrgID          string = "ORG_ID"
+	OrgDisplayName string = "ORG_DISPLAY_NAME"
+	// ID of an existing SDDC used for sddc data source, site recovery and srm node tests
+	TestSDDCId string = "TEST_SDDC_ID"
+	// Name of an existing SDDC used for sddc data source tests
 	TestSDDCName        string = "TEST_SDDC_NAME"
 	AWSAccountNumber    string = "AWS_ACCOUNT_NUMBER"
 	NSXTReverseProxyUrl string = "NSXT_REVERSE_PROXY_URL"

--- a/vmc/data_source_vmc_sddc.go
+++ b/vmc/data_source_vmc_sddc.go
@@ -103,6 +103,48 @@ func dataSourceVmcSddc() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			// Below are added as part of the schema as they are set in the
+			// dataSourceVmcSddcRead method
+			"updated": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"user_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_by_user_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"version": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"updated_by_user_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"user_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"org_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"account_link_state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"sddc_access_state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -131,16 +173,18 @@ func dataSourceVmcSddcRead(d *schema.ResourceData, m interface{}) error {
 	d.SetId(sddc.Id)
 
 	d.Set("sddc_name", sddc.Name)
-	d.Set("updated", sddc.Updated)
+	d.Set("updated", sddc.Updated.String())
 	d.Set("user_id", sddc.UserId)
 	d.Set("updated_by_user_id", sddc.UpdatedByUserId)
-	d.Set("created", sddc.Created)
+	d.Set("created", sddc.Created.String())
 	d.Set("version", sddc.Version)
 	d.Set("updated_by_user_name", sddc.UpdatedByUserName)
 	d.Set("user_name", sddc.UserName)
 	d.Set("org_id", sddc.OrgId)
 	d.Set("sddc_type", sddc.SddcType)
-	d.Set("provider", sddc.Provider)
+	// the key "provider" is reserved by the Terraform SDK, however the same information
+	// is carried by the sddc.ResourceConfig.Provider variable
+	//d.Set("provider", sddc.Provider)
 	d.Set("account_link_state", sddc.AccountLinkState)
 	d.Set("sddc_access_state", sddc.SddcAccessState)
 	d.Set("sddc_type", sddc.SddcType)

--- a/vmc/data_source_vmc_sddc_test.go
+++ b/vmc/data_source_vmc_sddc_test.go
@@ -19,7 +19,7 @@ func TestAccDataSourceVmcSddc_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceVmcSddcConfig(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.vmc_sddc.my_sddc", "sddc_name", os.Getenv(TestSDDCName)),
+					resource.TestCheckResourceAttr("data.vmc_sddc.sddc_imported", "sddc_name", os.Getenv(TestSDDCName)),
 				),
 			},
 		},
@@ -28,7 +28,7 @@ func TestAccDataSourceVmcSddc_basic(t *testing.T) {
 
 func testAccDataSourceVmcSddcConfig() string {
 	return fmt.Sprintf(`
-data "vmc_sddc" "my_sddc" {
+data "vmc_sddc" "sddc_imported" {
 	sddc_id = %q
 }
 `,

--- a/vmc/provider.go
+++ b/vmc/provider.go
@@ -45,14 +45,14 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("ORG_ID", nil),
 			},
 			"vmc_url": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "https://vmc.vmware.com",
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc(VMCUrl, DefaultVMCUrl),
 			},
 			"csp_url": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "https://console.cloud.vmware.com",
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc(CSPUrl, DefaultCSPUrl),
 			},
 		},
 
@@ -84,6 +84,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	os.Setenv(APIToken, refreshToken)
 	vmcURL := d.Get("vmc_url").(string)
 	cspURL := d.Get("csp_url").(string)
+	os.Setenv(CSPUrl, cspURL)
 	orgID := d.Get("org_id").(string)
 	httpClient := http.Client{}
 	connector, err := NewClientConnectorByRefreshToken(refreshToken, vmcURL, cspURL, httpClient)

--- a/vmc/provider_test.go
+++ b/vmc/provider_test.go
@@ -55,3 +55,18 @@ func testAccPreCheck(t *testing.T) {
 		t.Fatal(NSXTReverseProxyUrl + " must be set for acceptance tests")
 	}
 }
+
+// testAccPreCheckZerocloud this function validates a smaller set ot
+// environment variables needed for lightweight E2E testing using
+// the Zerocloud SDDC cloud provider option
+func testAccPreCheckZerocloud(t *testing.T) {
+	if v := os.Getenv(APIToken); v == "" {
+		t.Fatal(APIToken + " must be set for acceptance tests")
+	}
+	if v := os.Getenv(OrgID); v == "" {
+		t.Fatal(OrgID + " must be set for acceptance tests")
+	}
+	if v := os.Getenv(AWSAccountNumber); v == "" {
+		t.Fatal(AWSAccountNumber + " must be set for acceptance tests")
+	}
+}

--- a/vmc/resource_vmc_sddc.go
+++ b/vmc/resource_vmc_sddc.go
@@ -65,6 +65,306 @@ func resourceSddc() *schema.Resource {
 	}
 }
 
+// sddcSchema this helper function extracts the creation of the SDDC schema, so that
+// it's made available for mocking in tests.
+func sddcSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"storage_capacity": {
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				"15TB", "20TB", "25TB", "30TB", "35TB"}, false),
+		},
+		"sddc_name": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ValidateFunc: validation.NoZeroValues,
+		},
+		"size": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Default:  MediumSDDCSize,
+			ValidateFunc: validation.StringInSlice([]string{
+				MediumSDDCSize, CapitalMediumSDDCSize, LargeSDDCSize, CapitalLargeSDDCSize}, false),
+			Description: "The size of the vCenter and NSX appliances. 'large' or 'LARGE' SDDC size corresponds to a large vCenter appliance and large NSX appliance. 'medium' or 'MEDIUM' SDDC size corresponds to medium vCenter appliance and medium NSX appliance. Default : 'medium'.",
+		},
+		"account_link_sddc_config": {
+			Type: schema.TypeList,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"customer_subnet_ids": {
+						Type: schema.TypeList,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+						Optional: true,
+					},
+					"connected_account_id": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+			Optional: true,
+			ForceNew: true,
+		},
+		"vpc_cidr": {
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+		},
+		"num_host": {
+			Type:         schema.TypeInt,
+			Required:     true,
+			ValidateFunc: validation.IntAtLeast(1),
+		},
+		"sddc_type": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"vxlan_subnet": {
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+		},
+		"delay_account_link": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+			ForceNew: true,
+		},
+		"provider_type": {
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+			Default:  AWSProviderType,
+			ValidateFunc: validation.StringInSlice([]string{
+				AWSProviderType, ZeroCloudProviderType}, false),
+		},
+		"skip_creating_vxlan": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  true,
+			ForceNew: true,
+		},
+		"sso_domain": {
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+			Default:  "vmc.local",
+		},
+		"sddc_template_id": {
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+		},
+		"deployment_type": {
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+			Default:  SingleAvailabilityZone,
+			ValidateFunc: validation.StringInSlice([]string{
+				SingleAvailabilityZone, MultiAvailabilityZone,
+			}, false),
+		},
+		"region": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+			ValidateFunc: validation.All(
+				validation.NoZeroValues,
+			),
+			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+				return old == strings.ReplaceAll(strings.ToUpper(new), "-", "_")
+			},
+		},
+		"cluster_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"host_instance_type": {
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+			ValidateFunc: validation.StringInSlice(
+				[]string{HostInstancetypeI3, HostInstancetypeR5, HostInstancetypeI3EN, HostInstancetypeI4I}, false),
+		},
+		"edrs_policy_type": {
+			Type: schema.TypeString,
+			// Exact value known after create
+			Optional: true,
+			Computed: true,
+			ValidateFunc: validation.StringInSlice(
+				[]string{StorageScaleUpPolicyType, CostPolicyType, PerformancePolicyType, RapidScaleUpPolicyType}, false),
+			Description: "The EDRS policy type. This can either be 'cost', 'performance', 'storage-scaleup' or 'rapid-scaleup'. Default : storage-scaleup. ",
+		},
+		"enable_edrs": {
+			Type: schema.TypeBool,
+			// Value can be changed after create
+			Optional:    true,
+			Computed:    true,
+			Description: "True if EDRS is enabled",
+		},
+		"min_hosts": {
+			Type: schema.TypeInt,
+			// Exact value known after create
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: validation.IntBetween(MinHosts, MaxHosts),
+			Description:  "The minimum number of hosts that the cluster can scale in to.",
+		},
+		"max_hosts": {
+			Type: schema.TypeInt,
+			// Exact value known after create
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: validation.IntBetween(MinHosts, MaxHosts),
+			Description:  "The maximum number of hosts that the cluster can scale out to.",
+		},
+		"microsoft_licensing_config": {
+			Type: schema.TypeList,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"mssql_licensing": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "The status of MSSQL licensing for this SDDC’s clusters. Possible values : enabled, ENABLED, disabled, DISABLED.",
+						ValidateFunc: validation.StringInSlice([]string{
+							LicenseConfigEnabled, LicenseConfigDisabled, CapitalLicenseConfigEnabled, CapitalLicenseConfigDisabled}, false),
+					},
+					"windows_licensing": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "The status of Windows licensing for this SDDC's clusters. Possible values : enabled, ENABLED, disabled, DISABLED.",
+						ValidateFunc: validation.StringInSlice([]string{
+							LicenseConfigEnabled, LicenseConfigDisabled, CapitalLicenseConfigEnabled, CapitalLicenseConfigDisabled}, false),
+					},
+				},
+			},
+			Optional:    true,
+			Description: "Indicates the desired licensing support, if any, of Microsoft software.",
+		},
+		"intranet_mtu_uplink": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Default:      MinIntranetMTULink,
+			Description:  "Uplink MTU of direct connect, SDDC-grouping and outposts traffic in edge tier-0 router port.",
+			ValidateFunc: validation.IntBetween(MinIntranetMTULink, MaxIntranetMTULink),
+		},
+		"sddc_state": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"vc_url": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"cloud_username": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"cloud_password": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"nsxt_reverse_proxy_url": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"cluster_info": {
+			Type:     schema.TypeMap,
+			Computed: true,
+		},
+		"sddc_size": {
+			Type:     schema.TypeMap,
+			Computed: true,
+		},
+		"availability_zones": {
+			Type:     schema.TypeList,
+			Computed: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+		"nsxt_ui": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Computed: true,
+		},
+		"nsxt_cloudadmin": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"nsxt_cloudadmin_password": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"nsxt_cloudaudit": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"nsxt_cloudaudit_password": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"nsxt_private_ip": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"nsxt_private_url": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		// Following properties are set in the resourceSddcRead function and need to be
+		// present in the schema during E2E test result validation phase
+		"updated": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"user_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"updated_by_user_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"created": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"version": {
+			Type:     schema.TypeInt,
+			Computed: true,
+		},
+		"updated_by_user_name": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"user_name": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"org_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"account_link_state": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"sddc_access_state": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+	}
+}
+
 func resourceSddcCreate(d *schema.ResourceData, m interface{}) error {
 	connectorWrapper := m.(*ConnectorWrapper)
 	sddcClient := orgs.NewSddcsClient(connectorWrapper)
@@ -84,6 +384,8 @@ func resourceSddcCreate(d *schema.ResourceData, m interface{}) error {
 	// Wait until Sddc is created
 	sddcID := task.ResourceId
 	d.SetId(*sddcID)
+	maxServiceUnavailableRetries := 20
+	serviceUnavailableRetries := 0
 	return resource.RetryContext(context.Background(), d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		tasksClient := orgs.NewTasksClient(connectorWrapper)
 		task, err := tasksClient.Get(orgID, task.Id)
@@ -96,11 +398,22 @@ func resourceSddcCreate(d *schema.ResourceData, m interface{}) error {
 				}
 				return resource.RetryableError(fmt.Errorf("instance creation still in progress"))
 			}
+			// Resiliency in case of difficulties the VMC service may experience,
+			// during the significant SDDC provisioning time
+			if err.Error() == (errors.ServiceUnavailable{}.Error()) {
+				serviceUnavailableRetries++
+				if serviceUnavailableRetries <= maxServiceUnavailableRetries {
+					return resource.RetryableError(fmt.Errorf(
+						"VMC backend is experiencing difficulties, retry to polling the SDDC Create Task"))
+				} else {
+					return resource.NonRetryableError(fmt.Errorf("VMC service is down"))
+				}
+			}
 			return resource.NonRetryableError(fmt.Errorf("error creating SDDC : %v", err))
 
 		}
 		if *task.Status == "FAILED" {
-			return resource.NonRetryableError(fmt.Errorf("task failed to create SDDC"))
+			return resource.NonRetryableError(fmt.Errorf("task failed to create SDDC: %s", *task.ErrorMessage))
 		} else if *task.Status != "FINISHED" {
 			return resource.RetryableError(fmt.Errorf("expected SDDC to be created but was in state %s", *task.Status))
 		}
@@ -130,16 +443,20 @@ func resourceSddcRead(d *schema.ResourceData, m interface{}) error {
 	d.SetId(sddc.Id)
 
 	d.Set("sddc_name", sddc.Name)
-	d.Set("updated", sddc.Updated)
+	// The Terraform SDK does not support the use of time.Time type, so save the string
+	// representation
+	d.Set("updated", sddc.Updated.String())
 	d.Set("user_id", sddc.UserId)
 	d.Set("updated_by_user_id", sddc.UpdatedByUserId)
-	d.Set("created", sddc.Created)
+	d.Set("created", sddc.Created.String())
 	d.Set("version", sddc.Version)
 	d.Set("updated_by_user_name", sddc.UpdatedByUserName)
 	d.Set("user_name", sddc.UserName)
 	d.Set("org_id", sddc.OrgId)
 	d.Set("sddc_type", sddc.SddcType)
-	d.Set("provider", sddc.Provider)
+	// the key "provider" is reserved by the Terraform SDK, however the same information
+	// is provided by the sddc.ResourceConfig.Provider variable
+	//d.Set("provider", sddc.Provider)
 	d.Set("account_link_state", sddc.AccountLinkState)
 	d.Set("sddc_access_state", sddc.SddcAccessState)
 	d.Set("sddc_state", sddc.SddcState)
@@ -498,256 +815,6 @@ func resourceSddcUpdate(d *schema.ResourceData, m interface{}) error {
 		})
 	}
 	return resourceSddcRead(d, m)
-}
-
-// sddcSchema this helper function extracts the creation of the SDDC schema, so that
-// it's made available for mocking in tests.
-func sddcSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"storage_capacity": {
-			Type:     schema.TypeString,
-			Optional: true,
-			ForceNew: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				"15TB", "20TB", "25TB", "30TB", "35TB"}, false),
-		},
-		"sddc_name": {
-			Type:         schema.TypeString,
-			Required:     true,
-			ValidateFunc: validation.NoZeroValues,
-		},
-		"size": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Default:  MediumSDDCSize,
-			ValidateFunc: validation.StringInSlice([]string{
-				MediumSDDCSize, CapitalMediumSDDCSize, LargeSDDCSize, CapitalLargeSDDCSize}, false),
-			Description: "The size of the vCenter and NSX appliances. 'large' or 'LARGE' SDDC size corresponds to a large vCenter appliance and large NSX appliance. 'medium' or 'MEDIUM' SDDC size corresponds to medium vCenter appliance and medium NSX appliance. Default : 'medium'.",
-		},
-		"account_link_sddc_config": {
-			Type: schema.TypeList,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"customer_subnet_ids": {
-						Type: schema.TypeList,
-						Elem: &schema.Schema{
-							Type: schema.TypeString,
-						},
-						Optional: true,
-					},
-					"connected_account_id": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-				},
-			},
-			Optional: true,
-			ForceNew: true,
-		},
-		"vpc_cidr": {
-			Type:     schema.TypeString,
-			Optional: true,
-			ForceNew: true,
-		},
-		"num_host": {
-			Type:         schema.TypeInt,
-			Required:     true,
-			ValidateFunc: validation.IntAtLeast(1),
-		},
-		"sddc_type": {
-			Type:     schema.TypeString,
-			Optional: true,
-		},
-		"vxlan_subnet": {
-			Type:     schema.TypeString,
-			Optional: true,
-			ForceNew: true,
-		},
-		"delay_account_link": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Default:  false,
-			ForceNew: true,
-		},
-		"provider_type": {
-			Type:     schema.TypeString,
-			Optional: true,
-			ForceNew: true,
-			Default:  AWSProviderType,
-			ValidateFunc: validation.StringInSlice([]string{
-				AWSProviderType, ZeroCloudProviderType}, false),
-		},
-		"skip_creating_vxlan": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Default:  true,
-			ForceNew: true,
-		},
-		"sso_domain": {
-			Type:     schema.TypeString,
-			Optional: true,
-			ForceNew: true,
-			Default:  "vmc.local",
-		},
-		"sddc_template_id": {
-			Type:     schema.TypeString,
-			Optional: true,
-			ForceNew: true,
-		},
-		"deployment_type": {
-			Type:     schema.TypeString,
-			Optional: true,
-			ForceNew: true,
-			Default:  SingleAvailabilityZone,
-			ValidateFunc: validation.StringInSlice([]string{
-				SingleAvailabilityZone, MultiAvailabilityZone,
-			}, false),
-		},
-		"region": {
-			Type:     schema.TypeString,
-			Required: true,
-			ForceNew: true,
-			ValidateFunc: validation.All(
-				validation.NoZeroValues,
-			),
-			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-				return old == strings.ReplaceAll(strings.ToUpper(new), "-", "_")
-			},
-		},
-		"cluster_id": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"host_instance_type": {
-			Type:     schema.TypeString,
-			Optional: true,
-			ForceNew: true,
-			ValidateFunc: validation.StringInSlice(
-				[]string{HostInstancetypeI3, HostInstancetypeR5, HostInstancetypeI3EN, HostInstancetypeI4I}, false),
-		},
-		"edrs_policy_type": {
-			Type:     schema.TypeString,
-			Optional: true,
-			ValidateFunc: validation.StringInSlice(
-				[]string{StorageScaleUpPolicyType, CostPolicyType, PerformancePolicyType, RapidScaleUpPolicyType}, false),
-			Description: "The EDRS policy type. This can either be 'cost', 'performance', 'storage-scaleup' or 'rapid-scaleup'. Default : storage-scaleup. ",
-		},
-		"enable_edrs": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Description: "True if EDRS is enabled",
-		},
-		"min_hosts": {
-			Type:         schema.TypeInt,
-			Optional:     true,
-			ValidateFunc: validation.IntBetween(MinHosts, MaxHosts),
-			Description:  "The minimum number of hosts that the cluster can scale in to.",
-		},
-		"max_hosts": {
-			Type:         schema.TypeInt,
-			Optional:     true,
-			ValidateFunc: validation.IntBetween(MinHosts, MaxHosts),
-			Description:  "The maximum number of hosts that the cluster can scale out to.",
-		},
-		"microsoft_licensing_config": {
-			Type: schema.TypeList,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"mssql_licensing": {
-						Type:        schema.TypeString,
-						Optional:    true,
-						Description: "The status of MSSQL licensing for this SDDC’s clusters. Possible values : enabled, ENABLED, disabled, DISABLED.",
-						ValidateFunc: validation.StringInSlice([]string{
-							LicenseConfigEnabled, LicenseConfigDisabled, CapitalLicenseConfigEnabled, CapitalLicenseConfigDisabled}, false),
-					},
-					"windows_licensing": {
-						Type:        schema.TypeString,
-						Optional:    true,
-						Description: "The status of Windows licensing for this SDDC's clusters. Possible values : enabled, ENABLED, disabled, DISABLED.",
-						ValidateFunc: validation.StringInSlice([]string{
-							LicenseConfigEnabled, LicenseConfigDisabled, CapitalLicenseConfigEnabled, CapitalLicenseConfigDisabled}, false),
-					},
-				},
-			},
-			Optional:    true,
-			Description: "Indicates the desired licensing support, if any, of Microsoft software.",
-		},
-		"intranet_mtu_uplink": {
-			Type:         schema.TypeInt,
-			Optional:     true,
-			Default:      MinIntranetMTULink,
-			Description:  "Uplink MTU of direct connect, SDDC-grouping and outposts traffic in edge tier-0 router port.",
-			ValidateFunc: validation.IntBetween(MinIntranetMTULink, MaxIntranetMTULink),
-		},
-		"sddc_state": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"vc_url": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"cloud_username": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"cloud_password": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"nsxt_reverse_proxy_url": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"cluster_info": {
-			Type:     schema.TypeMap,
-			Computed: true,
-		},
-		"sddc_size": {
-			Type:     schema.TypeMap,
-			Computed: true,
-		},
-		"availability_zones": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-		},
-		"nsxt_ui": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Computed: true,
-		},
-		"nsxt_cloudadmin": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"nsxt_cloudadmin_password": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"nsxt_cloudaudit": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"nsxt_cloudaudit_password": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"nsxt_private_ip": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"nsxt_private_url": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-	}
 }
 
 // buildAwsSddcConfig extracts the creation of the model.AwsSddcConfig, so that it's

--- a/vmc/resource_vmc_sddc.go
+++ b/vmc/resource_vmc_sddc.go
@@ -404,9 +404,10 @@ func resourceSddcCreate(d *schema.ResourceData, m interface{}) error {
 				serviceUnavailableRetries++
 				if serviceUnavailableRetries <= maxServiceUnavailableRetries {
 					return resource.RetryableError(fmt.Errorf(
-						"VMC backend is experiencing difficulties, retry to polling the SDDC Create Task"))
+						"VMC backend is experiencing difficulties, retry %d from %d to polling the SDDC Create Task",
+						serviceUnavailableRetries, maxServiceUnavailableRetries))
 				} else {
-					return resource.NonRetryableError(fmt.Errorf("VMC service is down"))
+					return resource.NonRetryableError(fmt.Errorf("max ServiceUnavailable retries (20) reached to create SDDC"))
 				}
 			}
 			return resource.NonRetryableError(fmt.Errorf("error creating SDDC : %v", err))

--- a/vmc/utils.go
+++ b/vmc/utils.go
@@ -82,7 +82,8 @@ func getNSXTReverseProxyURLConnector(nsxtReverseProxyUrl string) (client.Connect
 	}
 	nsxtReverseProxyUrl = strings.Replace(nsxtReverseProxyUrl, SksNSXTManager, "", -1)
 	httpClient := http.Client{}
-	connector, err := NewClientConnectorByRefreshToken(apiToken, nsxtReverseProxyUrl, DefaultCSPUrl, httpClient)
+	cspUrl := os.Getenv(CSPUrl)
+	connector, err := NewClientConnectorByRefreshToken(apiToken, nsxtReverseProxyUrl, cspUrl, httpClient)
 	if err != nil {
 		return nil, HandleCreateError("NSXT reverse proxy URL connector", err)
 	}


### PR DESCRIPTION
… provider option

The usage of ZEROCLOUD provides the ability for the VMC Terraform provider to run an lightweight E2E test for ~100 s and zero infrastructure cost, while testing the whole SDDC lifecycle (including the create, get and delete APIs).

A subsequent change will introduce the GitHub actions yaml configuration to run the E2E acceptance test daily.

Changes:
The schema for SDDC adds missing properties, that are set by the resourceSddcRead post SDDC creation. The Terraform SDK complained about them while in acceptance test mode.

The SDDC schema properties: edrs_policy_type,  enable_edrs, min_hosts, max_hosts are now optional-computed as their value is NOT taken into account during initial SDDC creation and is computed by the VMC API. This makes any user-set values differ from what the VMC has set upon creation and running "terraform apply" on the newly created resource whould entail a change. This fails the E2E post-create validation and has been an inconvenience for our users, see:

https://github.com/vmware/terraform-provider-vmc/issues/94

Introduced the TestVMCUrl and TestCSPUrl environment variables, to enable setting the VMC and CSP service URLs for test purposes, without exposing them to the general public.

Introduces the TestAccResourceVmcSddc_Zerocloud, which is a copy of the existing TestAccResourceVmcSddc_basic, but using the ZEROCLOUD cloud provider option and a bit less checks, as the resulting SDDC is limited.

Testing done:
make build - passes
golangci-lint run - passes

Before change:
No acceptance tests ran successfully.
Right after SDDC creation running "terraform plan/apply" reported that changes are required in regard to "edrs_policy_type", "enable_edrs", "min_hosts", "max_hosts" properties, even without changes to desired configuration expressed in *.tf file.

After change:
make testacc TESTARGS="-run=TestAccResourceVmcSddc_Zerocloud" - multiple passes within 120 s

Deployed SDDC.
ran "terraform plan/apply" - no changes in regard to "edrs_policy_type", "enable_edrs", "min_hosts", "max_hosts" properties

Signed-off-by: Dimitar Proynov <proynovd@vmware.com>