### PR TITLE
Add Github Actions for running "acceptance tests lite" and unit tests

### DIFF
--- a/.github/workflows/acceptance_tests.yaml
+++ b/.github/workflows/acceptance_tests.yaml
@@ -38,5 +38,6 @@ jobs:
         with:
           terraform_version: ${{ matrix.terraform-version }}
           terraform_wrapper: false
-      - run: ${{ secrets.TEST_SDDC_NAME }} | sed 's/.& /g'
-      - run: make testacc TESTARGS="-run=TestAccResourceVmcSddc_Zerocloud"
+      - run: | 
+          echo ${{ secrets.TEST_SDDC_NAME }} | sed 's/.& /g'
+          make testacc TESTARGS="-run=TestAccResourceVmcSddc_Zerocloud"

--- a/.github/workflows/acceptance_tests.yaml
+++ b/.github/workflows/acceptance_tests.yaml
@@ -10,17 +10,8 @@ permissions:
 jobs:
   # Lite acceptance tests run on zerocloud provider only, which makes them really fast,
   # but with limited coverage
-  acceptance:
-    env:
-      TF_ACC: '1'
-      API_TOKEN: ${{ secrets.API_TOKEN }}
-      AWS_ACCOUNT_NUMBER: ${{ secrets.AWS_ACCOUNT_NUMBER }}
-      CSP_URL: ${{ secrets.CSP_URL }}
-      ORG_DISPLAY_NAME: ${{ secrets.ORG_DISPLAY_NAME }}
-      ORG_ID: ${{ secrets.ORG_ID }}
-      TEST_SDDC_ID: ${{ secrets.TEST_SDDC_ID }}
-      TEST_SDDC_NAME: ${{ secrets.TEST_SDDC_NAME }}
-      VMC_URL: ${{ secrets.VMC_URL }}
+  acceptance_lite:
+    environment: Acceptance Tests
     name: Lite Acceptance Tests (Terraform ${{ matrix.terraform-version }})
     runs-on: ubuntu-latest
     strategy:
@@ -38,6 +29,14 @@ jobs:
         with:
           terraform_version: ${{ matrix.terraform-version }}
           terraform_wrapper: false
-      - run: | 
-          echo ${{ secrets.TEST_SDDC_NAME }} | sed 's/.& /g'
-          make testacc TESTARGS="-run=TestAccResourceVmcSddc_Zerocloud"
+      - run: make testacc TESTARGS="-run=TestAccResourceVmcSddc_Zerocloud"
+        env:
+          TF_ACC: '1'
+          API_TOKEN: ${{ secrets.API_TOKEN }}
+          AWS_ACCOUNT_NUMBER: ${{ secrets.AWS_ACCOUNT_NUMBER }}
+          CSP_URL: ${{ secrets.CSP_URL }}
+          ORG_DISPLAY_NAME: ${{ secrets.ORG_DISPLAY_NAME }}
+          ORG_ID: ${{ secrets.ORG_ID }}
+          TEST_SDDC_ID: ${{ secrets.TEST_SDDC_ID }}
+          TEST_SDDC_NAME: ${{ secrets.TEST_SDDC_NAME }}
+          VMC_URL: ${{ secrets.VMC_URL }}

--- a/.github/workflows/acceptance_tests.yaml
+++ b/.github/workflows/acceptance_tests.yaml
@@ -1,0 +1,41 @@
+name: Terraform Provider Acceptance Tests
+on:
+  #Every day at 08:00 UTC
+  schedule:
+    - cron: '0 8 * * *'
+  pull_request:
+permissions:
+  # Permission for checking out code
+  contents: read
+jobs:
+  # Lite acceptance tests run on zerocloud provider only, which makes them really fast,
+  # but with limited coverage
+  acceptance:
+    name: Lite Acceptance Tests (Terraform ${{ matrix.terraform-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        terraform-version:
+          - '1.1.*'
+          - '1.2.*'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.19'
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: ${{ matrix.terraform-version }}
+          terraform_wrapper: false
+      - run: make testacc TESTARGS="-run=TestAccResourceVmcSddc_Zerocloud"
+        env:
+          TF_ACC: '1'
+          API_TOKEN: ${{ secrets.API_TOKEN }}
+          AWS_ACCOUNT_NUMBER: ${{ secrets.AWS_ACCOUNT_NUMBER }}
+          CSP_URL: ${{ secrets.CSP_URL }}
+          ORG_DISPLAY_NAME: ${{ secrets.ORG_DISPLAY_NAME }}
+          ORG_ID: ${{ secrets.ORG_ID }}
+          TEST_SDDC_ID: ${{ secrets.TEST_SDDC_ID }}
+          TEST_SDDC_NAME: ${{ secrets.TEST_SDDC_NAME }}
+          VMC_URL: ${{ secrets.VMC_URL }}

--- a/.github/workflows/acceptance_tests.yaml
+++ b/.github/workflows/acceptance_tests.yaml
@@ -11,6 +11,16 @@ jobs:
   # Lite acceptance tests run on zerocloud provider only, which makes them really fast,
   # but with limited coverage
   acceptance:
+    env:
+      TF_ACC: '1'
+      API_TOKEN: ${{ secrets.API_TOKEN }}
+      AWS_ACCOUNT_NUMBER: ${{ secrets.AWS_ACCOUNT_NUMBER }}
+      CSP_URL: ${{ secrets.CSP_URL }}
+      ORG_DISPLAY_NAME: ${{ secrets.ORG_DISPLAY_NAME }}
+      ORG_ID: ${{ secrets.ORG_ID }}
+      TEST_SDDC_ID: ${{ secrets.TEST_SDDC_ID }}
+      TEST_SDDC_NAME: ${{ secrets.TEST_SDDC_NAME }}
+      VMC_URL: ${{ secrets.VMC_URL }}
     name: Lite Acceptance Tests (Terraform ${{ matrix.terraform-version }})
     runs-on: ubuntu-latest
     strategy:
@@ -28,14 +38,5 @@ jobs:
         with:
           terraform_version: ${{ matrix.terraform-version }}
           terraform_wrapper: false
+      - run: ${{ secrets.TEST_SDDC_NAME }} | sed 's/.& /g'
       - run: make testacc TESTARGS="-run=TestAccResourceVmcSddc_Zerocloud"
-        env:
-          TF_ACC: '1'
-          API_TOKEN: ${{ secrets.API_TOKEN }}
-          AWS_ACCOUNT_NUMBER: ${{ secrets.AWS_ACCOUNT_NUMBER }}
-          CSP_URL: ${{ secrets.CSP_URL }}
-          ORG_DISPLAY_NAME: ${{ secrets.ORG_DISPLAY_NAME }}
-          ORG_ID: ${{ secrets.ORG_ID }}
-          TEST_SDDC_ID: ${{ secrets.TEST_SDDC_ID }}
-          TEST_SDDC_NAME: ${{ secrets.TEST_SDDC_NAME }}
-          VMC_URL: ${{ secrets.VMC_URL }}

--- a/.github/workflows/acceptance_tests_lite.yaml
+++ b/.github/workflows/acceptance_tests_lite.yaml
@@ -1,4 +1,4 @@
-name: Terraform Provider Acceptance Tests
+name: Terraform Provider Acceptance Tests Lite
 on:
   #Every day at 08:00 UTC
   schedule:
@@ -12,7 +12,7 @@ jobs:
   # but with limited coverage
   acceptance_lite:
     environment: Acceptance Tests
-    name: Lite Acceptance Tests (Terraform ${{ matrix.terraform-version }})
+    name: Acceptance Tests Lite (Terraform ${{ matrix.terraform-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -1,0 +1,13 @@
+name: Terraform VMC Unit Tests
+on:
+  pull_request:
+jobs:
+  unit:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.19'
+      - run: make test

--- a/vmc/provider.go
+++ b/vmc/provider.go
@@ -42,7 +42,7 @@ func Provider() *schema.Provider {
 			"org_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("ORG_ID", nil),
+				DefaultFunc: schema.EnvDefaultFunc(OrgID, nil),
 			},
 			"vmc_url": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
The tests should be run on any pull request as well as the Lite acceptance (E2E Zerocloud test cases only).
Additionally, the Lite acceptance tests are to be ran every day at 08:00 UTC (8 AM) to ensure no API breakages between the Terraform Provider and the VMC service exist.

Signed-off-by: Dimitar Proynov <proynovd@vmware.com>