### PR TITLE
Introduce GitHub actions to run lite E2E test on push and unit tests on pull request

### DIFF
--- a/.github/workflows/acceptance_tests.yaml
+++ b/.github/workflows/acceptance_tests.yaml
@@ -38,5 +38,6 @@ jobs:
         with:
           terraform_version: ${{ matrix.terraform-version }}
           terraform_wrapper: false
-      - run: ${{ secrets.TEST_SDDC_NAME }} | sed 's/.& /g'
-      - run: make testacc TESTARGS="-run=TestAccResourceVmcSddc_Zerocloud"
+      - run: | 
+          echo ${{ secrets.TEST_SDDC_NAME }} | sed 's/.& /g'
+          make testacc TESTARGS="-run=TestAccResourceVmcSddc_Zerocloud"

--- a/.github/workflows/acceptance_tests.yaml
+++ b/.github/workflows/acceptance_tests.yaml
@@ -10,17 +10,8 @@ permissions:
 jobs:
   # Lite acceptance tests run on zerocloud provider only, which makes them really fast,
   # but with limited coverage
-  acceptance:
-    env:
-      TF_ACC: '1'
-      API_TOKEN: ${{ secrets.API_TOKEN }}
-      AWS_ACCOUNT_NUMBER: ${{ secrets.AWS_ACCOUNT_NUMBER }}
-      CSP_URL: ${{ secrets.CSP_URL }}
-      ORG_DISPLAY_NAME: ${{ secrets.ORG_DISPLAY_NAME }}
-      ORG_ID: ${{ secrets.ORG_ID }}
-      TEST_SDDC_ID: ${{ secrets.TEST_SDDC_ID }}
-      TEST_SDDC_NAME: ${{ secrets.TEST_SDDC_NAME }}
-      VMC_URL: ${{ secrets.VMC_URL }}
+  acceptance_lite:
+    environment: Acceptance Tests
     name: Lite Acceptance Tests (Terraform ${{ matrix.terraform-version }})
     runs-on: ubuntu-latest
     strategy:
@@ -38,6 +29,14 @@ jobs:
         with:
           terraform_version: ${{ matrix.terraform-version }}
           terraform_wrapper: false
-      - run: | 
-          echo ${{ secrets.TEST_SDDC_NAME }} | sed 's/.& /g'
-          make testacc TESTARGS="-run=TestAccResourceVmcSddc_Zerocloud"
+      - run: make testacc TESTARGS="-run=TestAccResourceVmcSddc_Zerocloud"
+        env:
+          TF_ACC: '1'
+          API_TOKEN: ${{ secrets.API_TOKEN }}
+          AWS_ACCOUNT_NUMBER: ${{ secrets.AWS_ACCOUNT_NUMBER }}
+          CSP_URL: ${{ secrets.CSP_URL }}
+          ORG_DISPLAY_NAME: ${{ secrets.ORG_DISPLAY_NAME }}
+          ORG_ID: ${{ secrets.ORG_ID }}
+          TEST_SDDC_ID: ${{ secrets.TEST_SDDC_ID }}
+          TEST_SDDC_NAME: ${{ secrets.TEST_SDDC_NAME }}
+          VMC_URL: ${{ secrets.VMC_URL }}

--- a/.github/workflows/acceptance_tests.yaml
+++ b/.github/workflows/acceptance_tests.yaml
@@ -1,0 +1,41 @@
+name: Terraform Provider Acceptance Tests
+on:
+  #Every day at 08:00 UTC
+  schedule:
+    - cron: '0 8 * * *'
+  pull_request:
+permissions:
+  # Permission for checking out code
+  contents: read
+jobs:
+  # Lite acceptance tests run on zerocloud provider only, which makes them really fast,
+  # but with limited coverage
+  acceptance:
+    name: Lite Acceptance Tests (Terraform ${{ matrix.terraform-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        terraform-version:
+          - '1.1.*'
+          - '1.2.*'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.19'
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: ${{ matrix.terraform-version }}
+          terraform_wrapper: false
+      - run: make testacc TESTARGS="-run=TestAccResourceVmcSddc_Zerocloud"
+        env:
+          TF_ACC: '1'
+          API_TOKEN: ${{ secrets.API_TOKEN }}
+          AWS_ACCOUNT_NUMBER: ${{ secrets.AWS_ACCOUNT_NUMBER }}
+          CSP_URL: ${{ secrets.CSP_URL }}
+          ORG_DISPLAY_NAME: ${{ secrets.ORG_DISPLAY_NAME }}
+          ORG_ID: ${{ secrets.ORG_ID }}
+          TEST_SDDC_ID: ${{ secrets.TEST_SDDC_ID }}
+          TEST_SDDC_NAME: ${{ secrets.TEST_SDDC_NAME }}
+          VMC_URL: ${{ secrets.VMC_URL }}

--- a/.github/workflows/acceptance_tests.yaml
+++ b/.github/workflows/acceptance_tests.yaml
@@ -11,6 +11,16 @@ jobs:
   # Lite acceptance tests run on zerocloud provider only, which makes them really fast,
   # but with limited coverage
   acceptance:
+    env:
+      TF_ACC: '1'
+      API_TOKEN: ${{ secrets.API_TOKEN }}
+      AWS_ACCOUNT_NUMBER: ${{ secrets.AWS_ACCOUNT_NUMBER }}
+      CSP_URL: ${{ secrets.CSP_URL }}
+      ORG_DISPLAY_NAME: ${{ secrets.ORG_DISPLAY_NAME }}
+      ORG_ID: ${{ secrets.ORG_ID }}
+      TEST_SDDC_ID: ${{ secrets.TEST_SDDC_ID }}
+      TEST_SDDC_NAME: ${{ secrets.TEST_SDDC_NAME }}
+      VMC_URL: ${{ secrets.VMC_URL }}
     name: Lite Acceptance Tests (Terraform ${{ matrix.terraform-version }})
     runs-on: ubuntu-latest
     strategy:
@@ -28,14 +38,5 @@ jobs:
         with:
           terraform_version: ${{ matrix.terraform-version }}
           terraform_wrapper: false
+      - run: ${{ secrets.TEST_SDDC_NAME }} | sed 's/.& /g'
       - run: make testacc TESTARGS="-run=TestAccResourceVmcSddc_Zerocloud"
-        env:
-          TF_ACC: '1'
-          API_TOKEN: ${{ secrets.API_TOKEN }}
-          AWS_ACCOUNT_NUMBER: ${{ secrets.AWS_ACCOUNT_NUMBER }}
-          CSP_URL: ${{ secrets.CSP_URL }}
-          ORG_DISPLAY_NAME: ${{ secrets.ORG_DISPLAY_NAME }}
-          ORG_ID: ${{ secrets.ORG_ID }}
-          TEST_SDDC_ID: ${{ secrets.TEST_SDDC_ID }}
-          TEST_SDDC_NAME: ${{ secrets.TEST_SDDC_NAME }}
-          VMC_URL: ${{ secrets.VMC_URL }}

--- a/.github/workflows/acceptance_tests_lite.yaml
+++ b/.github/workflows/acceptance_tests_lite.yaml
@@ -1,4 +1,4 @@
-name: Terraform Provider Acceptance Tests
+name: Terraform Provider Acceptance Tests Lite
 on:
   #Every day at 08:00 UTC
   schedule:
@@ -12,7 +12,7 @@ jobs:
   # but with limited coverage
   acceptance_lite:
     environment: Acceptance Tests
-    name: Lite Acceptance Tests (Terraform ${{ matrix.terraform-version }})
+    name: Acceptance Tests Lite (Terraform ${{ matrix.terraform-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/acceptance_tests_lite.yaml
+++ b/.github/workflows/acceptance_tests_lite.yaml
@@ -11,7 +11,6 @@ jobs:
   # Lite acceptance tests run on zerocloud provider only, which makes them really fast,
   # but with limited coverage
   acceptance_lite:
-    environment: Acceptance Tests
     name: Acceptance Tests Lite (Terraform ${{ matrix.terraform-version }})
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/acceptance_tests_lite.yaml
+++ b/.github/workflows/acceptance_tests_lite.yaml
@@ -3,7 +3,7 @@ on:
   #Every day at 08:00 UTC
   schedule:
     - cron: '0 8 * * *'
-  pull_request:
+  push:
 permissions:
   # Permission for checking out code
   contents: read

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -6,9 +6,9 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.49.0
           args: --issues-exit-code=1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,17 +10,17 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       -
         name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.19.1
       -
         name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.49.0
           args: --issues-exit-code=1

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -1,0 +1,13 @@
+name: Terraform VMC Unit Tests
+on:
+  pull_request:
+jobs:
+  unit:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.19'
+      - run: make test

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Terraform to work with [VMware Cloud on AWS](https://vmc.vmware.com/).
 
 
 - [Terraform](https://www.terraform.io/downloads.html) 0.12+
-- [Go](https://golang.org/doc/install) 1.16 (to build the provider plugin)
+- [Go](https://golang.org/doc/install) 1.19 (to build the provider plugin)
 
 
 # Building the Provider
@@ -115,11 +115,17 @@ provider.
 Set required environment variables based as per your infrastructure settings
 
 ```sh
+$ # API token provided from CSP
 $ export API_TOKEN=xxx
+$ # Id of a VMC Org in which test SDDC are (to be) placed 
 $ export ORG_ID=xxxx
+$ # Id of an existing SDDC used for SDDC data source (import) test
 $ export TEST_SDDC_ID=xxx
+$ # Name of above SDDC
 $ export TEST_SDDC_NAME=xxx
+$ # NSX URL of a non-ZEROCLOUD SDDC, used for real IP testing
 $ export NSXT_REVERSE_PROXY_URL=xxx
+$ # Account number of a connected to the above Org AWS account, required for test SDDC deployment 
 $ export AWS_ACCOUNT_NUMBER=xxx
 ```
 
@@ -137,8 +143,15 @@ If you want to run against a specific set of tests, run make testacc with the TE
 $ make testacc TESTARGS="-run=TestAccResourceVmcSddc_basic"
 ```
 
+Additionally, limited set of acceptance tests can be ran with the ZEROCLOUD cloud provider, which is much faster and cheaper,
+while providing decent API coverage:
+
+```sh
+$ make testacc TESTARGS="-run=TestAccResourceVmcSddc_Zerocloud"
+```
+
 # License
 
-Copyright 2019 VMware, Inc.
+Copyright 2019-2022 VMware, Inc.
 
 The Terraform provider for VMware Cloud on AWS is available under [MPL2.0 license](https://github.com/vmware/terraform-provider-vmc/blob/master/LICENSE).

--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ provider.
 Set required environment variables based as per your infrastructure settings
 
 ```sh
-$ # API token provided from CSP
+$ # API token provided from CSP with at least "Organization Member" role and service role
+$ # on "VMware Cloud on AWS" service that is allowed to deploy SDDCs.
 $ export API_TOKEN=xxx
 $ # Id of a VMC Org in which test SDDC are (to be) placed 
 $ export ORG_ID=xxxx

--- a/vmc/provider.go
+++ b/vmc/provider.go
@@ -42,7 +42,7 @@ func Provider() *schema.Provider {
 			"org_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("ORG_ID", nil),
+				DefaultFunc: schema.EnvDefaultFunc(OrgID, nil),
 			},
 			"vmc_url": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
The Lite acceptance tests are to be ran every day at 08:00 UTC (8 AM) to ensure no API breakages between the Terraform Provider and the VMC service exist.

The trigger event "pull_request" is not allowed access to GitHub secrets from forked repositories for security reasons (the forked repo can merge malicious code that will reveal/steal the secrets). The next best trigger event will be "push".

Update README.md with copyright, add a bit of description to the test environment variable as well as mention the possibility of running tests against ZEROCLOUD environments.

Additionally, bump the marketplace actions used in the automation to latest versions.

Signed-off-by: Dimitar Proynov <proynovd@vmware.com>