### PR TITLE
Support primary cluster scale up/down in multi-cluster SDDC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.10.0 (Sep 20, 2022)
+## 1.10.1 (Sep 20, 2022)
 
 BUG FIXES:
 Defaults for enable_edrs, edrs_policy_type, max_hosts, min_hosts should not be set to null https://github.com/vmware/terraform-provider-vmc/issues/94

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.10.0 (Sep 20, 2022)
+
+BUG FIXES:
+Defaults for enable_edrs, edrs_policy_type, max_hosts, min_hosts should not be set to null https://github.com/vmware/terraform-provider-vmc/issues/94
+
 ## 1.10.0 (Jul 12, 2022)
 
 FEATURES:

--- a/examples/cluster/main.tf
+++ b/examples/cluster/main.tf
@@ -26,7 +26,7 @@ data "vmc_customer_subnets" "my_subnets" {
 resource "vmc_sddc" "sddc_1" {
   sddc_name           = var.sddc_name
   vpc_cidr            = var.vpc_cidr
-  num_host            = var.sddc_num_hosts
+  num_host            = var.sddc_primary_cluster_num_hosts
   provider_type       = var.provider_type
   region              = data.vmc_customer_subnets.my_subnets.region
   vxlan_subnet        = var.vxlan_subnet

--- a/examples/cluster/variables.tf
+++ b/examples/cluster/variables.tf
@@ -44,11 +44,11 @@ variable host_instance_type {
 }
 
 variable cluster_num_hosts {
-  description = "The number of hosts in the cluster."
+  description = "The number of hosts in the (secondary) cluster."
   default = 3
 }
 
-variable sddc_num_hosts {
-  description = "The number of hosts in SDDC."
+variable sddc_primary_cluster_num_hosts {
+  description = "The number of hosts in the primary cluster of the SDDC."
   default     = 3
 }

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -25,7 +25,7 @@ data "vmc_customer_subnets" "my_subnets" {
 resource "vmc_sddc" "sddc_1" {
   sddc_name           = var.sddc_name
   vpc_cidr            = var.vpc_cidr
-  num_host            = var.sddc_num_hosts
+  num_host            = var.sddc_primary_cluster_num_hosts
   provider_type       = var.provider_type
   region              = data.vmc_customer_subnets.my_subnets.region
   vxlan_subnet        = var.vxlan_subnet

--- a/examples/public_ip/main.tf
+++ b/examples/public_ip/main.tf
@@ -26,7 +26,7 @@ data "vmc_customer_subnets" "my_subnets" {
 resource "vmc_sddc" "sddc_1" {
   sddc_name           = var.sddc_name
   vpc_cidr            = var.vpc_cidr
-  num_host            = var.sddc_num_hosts
+  num_host            = var.sddc_primary_cluster_num_hosts
   provider_type       = var.provider_type
   region              = data.vmc_customer_subnets.my_subnets.region
   vxlan_subnet        = var.vxlan_subnet

--- a/examples/public_ip/variables.tf
+++ b/examples/public_ip/variables.tf
@@ -47,8 +47,8 @@ variable host_instance_type {
   default     = ""
 }
 
-variable sddc_num_hosts {
-  description = "The number of hosts in SDDC."
+variable sddc_primary_cluster_num_hosts {
+  description = "The number of hosts in the primary cluster of the SDDC."
   default     = 1
 }
 

--- a/examples/sddc/main.tf
+++ b/examples/sddc/main.tf
@@ -25,7 +25,7 @@ data "vmc_customer_subnets" "my_subnets" {
 resource "vmc_sddc" "sddc_1" {
   sddc_name           = var.sddc_name
   vpc_cidr            = var.vpc_cidr
-  num_host            = var.sddc_num_hosts
+  num_host            = var.sddc_primary_cluster_num_hosts
   provider_type       = var.provider_type
   region              = data.vmc_customer_subnets.my_subnets.region
   vxlan_subnet        = var.vxlan_subnet

--- a/examples/sddc/variables.tf
+++ b/examples/sddc/variables.tf
@@ -38,8 +38,8 @@ variable host_instance_type {
   default     = ""
 }
 
-variable sddc_num_hosts {
-  description = "The number of hosts in SDDC."
+variable sddc_primary_cluster_num_hosts {
+  description = "The number of hosts in the primary cluster of the SDDC."
   default     = 1
 }
 

--- a/examples/site_recovery/main.tf
+++ b/examples/site_recovery/main.tf
@@ -25,7 +25,7 @@ data "vmc_customer_subnets" "my_subnets" {
 resource "vmc_sddc" "sddc_1" {
   sddc_name           = var.sddc_name
   vpc_cidr            = var.vpc_cidr
-  num_host            = var.sddc_num_hosts
+  num_host            = var.sddc_primary_cluster_num_hosts
   provider_type       = var.provider_type
   region              = data.vmc_customer_subnets.my_subnets.region
   vxlan_subnet        = var.vxlan_subnet

--- a/examples/site_recovery/variables.tf
+++ b/examples/site_recovery/variables.tf
@@ -48,8 +48,8 @@ variable host_instance_type {
   default     = ""
 }
 
-variable sddc_num_hosts {
-  description = "The number of hosts in SDDC."
+variable sddc_primary_cluster_num_hosts {
+  description = "The number of hosts in the primary cluster of the SDDC."
   default     = 1
 }
 

--- a/examples/srm_node/main.tf
+++ b/examples/srm_node/main.tf
@@ -25,7 +25,7 @@ data "vmc_customer_subnets" "my_subnets" {
 resource "vmc_sddc" "sddc_1" {
   sddc_name           = var.sddc_name
   vpc_cidr            = var.vpc_cidr
-  num_host            = var.num_hosts
+  num_host            = var.sddc_primary_cluster_num_hosts
   provider_type       = var.provider_type
   region              = data.vmc_customer_subnets.my_subnets.region
   vxlan_subnet        = var.vxlan_subnet

--- a/examples/srm_node/variables.tf
+++ b/examples/srm_node/variables.tf
@@ -38,8 +38,8 @@ variable host_instance_type {
   default     = ""
 }
 
-variable num_hosts {
-  description = "The number of hosts."
+variable sddc_primary_cluster_num_hosts {
+  description = "The number of hosts in the primary cluster of the SDDC."
   default     = 1
 }
 

--- a/examples/stretched_cluster/main.tf
+++ b/examples/stretched_cluster/main.tf
@@ -25,7 +25,7 @@ data "vmc_customer_subnets" "my_subnets" {
 resource "vmc_sddc" "sddc_1" {
   sddc_name           = var.sddc_name
   vpc_cidr            = var.vpc_cidr
-  num_host            = var.sddc_num_hosts
+  num_host            = var.sddc_primary_cluster_num_hosts
   provider_type       = var.provider_type
   region              = data.vmc_customer_subnets.my_subnets.region
   vxlan_subnet        = var.vxlan_subnet

--- a/examples/stretched_cluster/variables.tf
+++ b/examples/stretched_cluster/variables.tf
@@ -38,8 +38,8 @@ variable host_instance_type {
   default     = ""
 }
 
-variable sddc_num_hosts {
-  description = "The number of hosts in SDDC."
+variable sddc_primary_cluster_num_hosts {
+  description = "The number of hosts in the primary cluster of the SDDC."
   default     = 6
 }
 

--- a/examples/variables.tf
+++ b/examples/variables.tf
@@ -44,8 +44,8 @@ variable host_instance_type {
   default     = ""
 }
 
-variable sddc_num_hosts {
-  description = "The number of hosts in SDDC."
+variable sddc_primary_cluster_num_hosts {
+  description = "The number of hosts in the primary cluster of the SDDC."
   default     = 1
 }
 

--- a/vmc/data_source_vmc_sddc.go
+++ b/vmc/data_source_vmc_sddc.go
@@ -202,7 +202,7 @@ func dataSourceVmcSddcRead(d *schema.ResourceData, m interface{}) error {
 		if err != nil {
 			return HandleReadError(d, "Primary Cluster", sddcID, err)
 		}
-		d.Set("num_host", getHostCountOnPrimaryCluster(&sddc, primaryCluster.ClusterId))
+		d.Set("num_host", getHostCountCluster(&sddc, primaryCluster.ClusterId))
 		d.Set("provider_type", sddc.ResourceConfig.Provider)
 		d.Set("availability_zones", sddc.ResourceConfig.AvailabilityZones)
 		d.Set("deployment_type", ConvertDeployType(*sddc.ResourceConfig.DeploymentType))

--- a/vmc/data_source_vmc_sddc.go
+++ b/vmc/data_source_vmc_sddc.go
@@ -5,6 +5,7 @@ package vmc
 
 import (
 	"fmt"
+	"github.com/vmware/vsphere-automation-sdk-go/services/vmc/orgs/sddcs"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -194,7 +195,14 @@ func dataSourceVmcSddcRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("cloud_username", sddc.ResourceConfig.CloudUsername)
 		d.Set("nsxt_reverse_proxy_url", sddc.ResourceConfig.NsxApiPublicEndpointUrl)
 		d.Set("region", sddc.ResourceConfig.Region)
-		d.Set("num_host", getTotalSddcHosts(&sddc))
+		// Query the API for primary Cluster ID so only it's hosts can be added to the
+		// sddc host
+		primaryClusterClient := sddcs.NewPrimaryclusterClient(connector)
+		primaryCluster, err := primaryClusterClient.Get(orgID, sddcID)
+		if err != nil {
+			return HandleReadError(d, "Primary Cluster", sddcID, err)
+		}
+		d.Set("num_host", getHostCountOnPrimaryCluster(&sddc, primaryCluster.ClusterId))
 		d.Set("provider_type", sddc.ResourceConfig.Provider)
 		d.Set("availability_zones", sddc.ResourceConfig.AvailabilityZones)
 		d.Set("deployment_type", ConvertDeployType(*sddc.ResourceConfig.DeploymentType))

--- a/vmc/data_source_vmc_sddc_test.go
+++ b/vmc/data_source_vmc_sddc_test.go
@@ -11,15 +11,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccDataSourceVmcSddc_basic(t *testing.T) {
+func TestAccDataSourceVmcSddcBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckZerocloud(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceVmcSddcConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.vmc_sddc.sddc_imported", "sddc_name", os.Getenv(TestSDDCName)),
+					// TODO: consider adding another env variable for the primary cluster host count
+					resource.TestCheckResourceAttr("data.vmc_sddc.sddc_imported", "num_host", "2"),
 				),
 			},
 		},

--- a/vmc/resource_vmc_sddc.go
+++ b/vmc/resource_vmc_sddc.go
@@ -492,9 +492,9 @@ func resourceSddcRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("sso_domain", *sddc.ResourceConfig.SsoDomain)
 		d.Set("skip_creating_vxlan", *sddc.ResourceConfig.SkipCreatingVxlan)
 		d.Set("provider_type", sddc.ResourceConfig.Provider)
-		// SDDS's num_host should account for the amount of hosts on its primary cluster only.
+		// SDDC's num_host should account for the amount of hosts on its primary cluster only.
 		// Otherwise, there will be no way to scale up or down the primary cluster.
-		d.Set("num_host", getHostCountOnPrimaryCluster(&sddc, primaryCluster.ClusterId))
+		d.Set("num_host", getHostCountCluster(&sddc, primaryCluster.ClusterId))
 		if sddc.ResourceConfig.VpcInfo != nil && sddc.ResourceConfig.VpcInfo.VpcCidr != nil {
 			d.Set("vpc_cidr", *sddc.ResourceConfig.VpcInfo.VpcCidr)
 		}

--- a/vmc/resource_vmc_sddc.go
+++ b/vmc/resource_vmc_sddc.go
@@ -118,6 +118,7 @@ func sddcSchema() map[string]*schema.Schema {
 			Type:         schema.TypeInt,
 			Required:     true,
 			ValidateFunc: validation.IntAtLeast(1),
+			Description:  "The amount of hosts in the primary cluster of the SDDC",
 		},
 		"sddc_type": {
 			Type:     schema.TypeString,

--- a/vmc/utils.go
+++ b/vmc/utils.go
@@ -90,19 +90,19 @@ func getNSXTReverseProxyURLConnector(nsxtReverseProxyUrl string) (client.Connect
 	return connector, nil
 }
 
-// getHostCountOnPrimaryCluster tries to find the amount of hosts on the primary Cluster in
+// getHostCountCluster tries to find the amount of hosts on a Cluster in
 // the ResourceConfig of the provided SDDC. If there is no ResourceConfig/Cluster 0 is returned.
-// The primary Cluster is distinguished by its id
-func getHostCountOnPrimaryCluster(sddc *model.Sddc, primaryClusterId string) int {
-	primaryClusterHostCount := 0
+// A Cluster is distinguished by its id
+func getHostCountCluster(sddc *model.Sddc, clusterId string) int {
+	clusterHostCount := 0
 	if sddc != nil && sddc.ResourceConfig != nil && sddc.ResourceConfig.Clusters != nil {
 		for _, cluster := range sddc.ResourceConfig.Clusters {
-			if cluster.ClusterId == primaryClusterId {
-				primaryClusterHostCount += len(cluster.EsxHostList)
+			if cluster.ClusterId == clusterId {
+				clusterHostCount += len(cluster.EsxHostList)
 			}
 		}
 	}
-	return primaryClusterHostCount
+	return clusterHostCount
 }
 
 // toHostInstanceType converts from the Schema format of the host_instance_type to

--- a/vmc/utils.go
+++ b/vmc/utils.go
@@ -35,7 +35,7 @@ func ConvertStorageCapacitytoInt(s string) int64 {
 	return storageCapacity
 }
 
-// Mapping for deployment_type field
+// ConvertDeployType Mapping for deployment_type field
 // During refresh/import state, return value of VMC API should be converted to uppercamel case in terraform
 // to maintain consistency
 func ConvertDeployType(s string) string {
@@ -90,14 +90,19 @@ func getNSXTReverseProxyURLConnector(nsxtReverseProxyUrl string) (client.Connect
 	return connector, nil
 }
 
-func getTotalSddcHosts(sddc *model.Sddc) int {
-	totalHosts := 0
-	if sddc != nil && sddc.ResourceConfig.Clusters != nil {
+// getHostCountOnPrimaryCluster tries to find the amount of hosts on the primary Cluster in
+// the ResourceConfig of the provided SDDC. If there is no ResourceConfig/Cluster 0 is returned.
+// The primary Cluster is distinguished by its id
+func getHostCountOnPrimaryCluster(sddc *model.Sddc, primaryClusterId string) int {
+	primaryClusterHostCount := 0
+	if sddc != nil && sddc.ResourceConfig != nil && sddc.ResourceConfig.Clusters != nil {
 		for _, cluster := range sddc.ResourceConfig.Clusters {
-			totalHosts += len(cluster.EsxHostList)
+			if cluster.ClusterId == primaryClusterId {
+				primaryClusterHostCount += len(cluster.EsxHostList)
+			}
 		}
 	}
-	return totalHosts
+	return primaryClusterHostCount
 }
 
 // toHostInstanceType converts from the Schema format of the host_instance_type to

--- a/vmc/utils_test.go
+++ b/vmc/utils_test.go
@@ -35,10 +35,10 @@ func TestToHostInstanceType(t *testing.T) {
 	}
 }
 
-func TestGetHostCountOnPrimaryCluster(t *testing.T) {
+func TestGetHostCountOnCluster(t *testing.T) {
 	type inputStruct struct {
-		sddc             *model.Sddc
-		primaryClusterId string
+		sddc      *model.Sddc
+		clusterId string
 	}
 	type test struct {
 		input inputStruct
@@ -92,7 +92,7 @@ func TestGetHostCountOnPrimaryCluster(t *testing.T) {
 		}, cluster1Id}, want: 1},
 	}
 	for _, testCase := range tests {
-		got := getHostCountOnPrimaryCluster(testCase.input.sddc, testCase.input.primaryClusterId)
+		got := getHostCountCluster(testCase.input.sddc, testCase.input.clusterId)
 		assert.Equal(t, got, testCase.want)
 	}
 }

--- a/vmc/utils_test.go
+++ b/vmc/utils_test.go
@@ -34,3 +34,65 @@ func TestToHostInstanceType(t *testing.T) {
 		assert.Equal(t, err, testCase.want.err)
 	}
 }
+
+func TestGetHostCountOnPrimaryCluster(t *testing.T) {
+	type inputStruct struct {
+		sddc             *model.Sddc
+		primaryClusterId string
+	}
+	type test struct {
+		input inputStruct
+		want  int
+	}
+	var cluster1Id = "Cluster-1"
+	var cluster2Id = "Cluster-2"
+	tests := []test{
+		{input: inputStruct{nil, cluster1Id}, want: 0},
+		{input: inputStruct{&model.Sddc{}, cluster1Id}, want: 0},
+		{input: inputStruct{&model.Sddc{
+			ResourceConfig: &model.AwsSddcResourceConfig{},
+		}, cluster1Id}, want: 0},
+		{input: inputStruct{&model.Sddc{
+			ResourceConfig: &model.AwsSddcResourceConfig{
+				Clusters: []model.Cluster{
+					{
+						ClusterId: cluster1Id,
+						EsxHostList: []model.AwsEsxHost{
+							{EsxId: new(string)},
+							{EsxId: new(string)},
+						},
+					},
+					{
+						ClusterId: cluster2Id,
+						EsxHostList: []model.AwsEsxHost{
+							{EsxId: new(string)},
+						},
+					},
+				},
+			},
+		}, cluster1Id}, want: 2},
+		{input: inputStruct{&model.Sddc{
+			ResourceConfig: &model.AwsSddcResourceConfig{
+				Clusters: []model.Cluster{
+					{
+						ClusterId: cluster1Id,
+						EsxHostList: []model.AwsEsxHost{
+							{EsxId: new(string)},
+						},
+					},
+					{
+						ClusterId: cluster2Id,
+						EsxHostList: []model.AwsEsxHost{
+							{EsxId: new(string)},
+							{EsxId: new(string)},
+						},
+					},
+				},
+			},
+		}, cluster1Id}, want: 1},
+	}
+	for _, testCase := range tests {
+		got := getHostCountOnPrimaryCluster(testCase.input.sddc, testCase.input.primaryClusterId)
+		assert.Equal(t, got, testCase.want)
+	}
+}


### PR DESCRIPTION

Currently scaling up/down primary cluster (the default one created together with an SDDC) is possible only on single cluster SDDC. The num_hosts property on SDDC is populated (post sddc provision) with the total number of hosts of all clusters on the sddc, which is always different to the user desired number in multi-cluster SDDC.

In that multi-cluster case after the initial "apply" any "plan" operation will show that the SDDC num_hosts is larger than the desired one, which is bad UX for a brand-new resource and erroneous behaviour according to the Terraform Acceptance tests framework, making any multi-cluster SDDC tests impossible to pass.

If user runs "apply" just after the initial provision an error message will be show, saying that "scaling is not supported for SDDC's with multiple clusters. Please add/delete hosts in individual cluster". However, there won't be any convenient way for the user to address the primary cluster (the one with name "Cluster-X-1") to scale it.

Thus, with this change the num_hosts property on an SDDC resource will control the amount of hosts in its primary cluster, making it possible to scale it up/down and preventing a subsequent "plan"/"apply" operation from trying to scale it down and breaking.

Fix for:
https://github.com/vmware/terraform-provider-vmc/issues/113

Testing done:
make build
make test

Deployed a multi-cluster SDDC
Ran "terraform plan" post provision -> no changes to SDDC num_hosts planed
Ran "terraform plan" -> no changes to SDDC num_hosts planed

Changed num_hosts on SDDC with +1 - successfully added a host to the primary cluster, confirmed via VMC UI
Changed num_hosts on SDDC with -1 - successfully removed a host from the primary cluster, confirmed via VMC UI

Changed num_hosts on Cluster with -1 - successfully removed a host from the secondary cluster, confirmed via VMC UI
Changed num_hosts on Cluster with +1 - successfully added a host to the secondary cluster, confirmed via VMC UI

Executed tests:
TestAccDataSourceVmcSddcBasic

Signed-off-by: Dimitar Proynov <proynovd@vmware.com>
