### PR TITLE
Intoduce lightweight Acceptance tests for Cluster and VMC Customer Subnets

### DIFF
--- a/vmc/data_source_vmc_customer_subnets_test.go
+++ b/vmc/data_source_vmc_customer_subnets_test.go
@@ -10,19 +10,22 @@ import (
 	"testing"
 )
 
-func TestAccDataSourceVmcCustomerSubnets_basic(t *testing.T) {
+func TestAccDataSourceVmcCustomerSubnetsBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckZerocloud(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceVmcCustomerSubnetsConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.vmc_customer_subnets.my_subnets", "ids.#", "4"),
-					resource.TestCheckResourceAttr("data.vmc_customer_subnets.my_subnets", "ids.0", "subnet-8cabb6f5"),
-					resource.TestCheckResourceAttr("data.vmc_customer_subnets.my_subnets", "ids.1", "subnet-1ecff155"),
-					resource.TestCheckResourceAttr("data.vmc_customer_subnets.my_subnets", "ids.2", "subnet-98fc13c5"),
-					resource.TestCheckResourceAttr("data.vmc_customer_subnets.my_subnets", "ids.3", "subnet-c895f2e3"),
+					// The following subnet IDs are tightly coupled to the AWS account number provided for testing.
+					// Since the provisioning of an AWS account incurs costs the hardcoded subnets IDs will have to do.
+					// If this tests fails it was probably ran with a different "AWSAccountNumber" than originally designed.
+					resource.TestCheckResourceAttr("data.vmc_customer_subnets.my_subnets", "ids.0", "subnet-01715c65359792049"),
+					resource.TestCheckResourceAttr("data.vmc_customer_subnets.my_subnets", "ids.1", "subnet-01d62fb7a6ef9ca1b"),
+					resource.TestCheckResourceAttr("data.vmc_customer_subnets.my_subnets", "ids.2", "subnet-0cd7c7fdd15b08b07"),
+					resource.TestCheckResourceAttr("data.vmc_customer_subnets.my_subnets", "ids.3", "subnet-08d5d9dc3aad0383a"),
 				),
 			},
 		},
@@ -41,5 +44,5 @@ data "vmc_customer_subnets" "my_subnets" {
 	region = "US_WEST_2"
 }
 `,
-		os.Getenv("AWS_ACCOUNT_NUMBER"))
+		os.Getenv(AWSAccountNumber))
 }


### PR DESCRIPTION
A lightweight acceptance test for resource cluster ensures API compatibility and makes any code refactors much more secure (fewer regressions).

In order to pass the ImportStateVerify check (a check that tests if the properties of the newly created resource are as expected) the host_instance_type and the microsoft_licensing_config have to be set in the cluster schema, as it is currently defined, not only under the cluster_info umbrella.

VMC connected accounts Acceptance test has existed in it's current form before, however it is tightly coupled with the AWSAccountNumber env variable passed. Automatic provisioning of AWS connected accounts is not possible, and each account has a real cost. Thus, hardcoding the IDs to check in the test makes sense.

Testing done:
make build
make test
golangci-lint run

make testacc TESTARGS="-run=TestAccResourceVmcClusterZerocloud"
...
--- PASS: TestAccResourceVmcClusterZerocloud (288.11s)
ok  	github.com/vmware/terraform-provider-vmc/vmc	288.334s

make testacc TESTARGS="-run=TestAccDataSourceVmcCustomerSubnetsBasic"
--- PASS: TestAccDataSourceVmcCustomerSubnetsBasic (13.03s)
PASS
ok  	github.com/vmware/terraform-provider-vmc/vmc	13.866s


Signed-off-by: Dimitar Proynov <proynovd@vmware.com>