### PR TITLE
Run lightweight acceptance tests for SDDC, Cluster, SRM, SRM Node, Cu…

### DIFF
--- a/.github/workflows/acceptance_tests_lite.yaml
+++ b/.github/workflows/acceptance_tests_lite.yaml
@@ -17,7 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         terraform-version:
-          - '1.1.*'
           - '1.2.*'
     steps:
       - uses: actions/checkout@v3
@@ -28,7 +27,7 @@ jobs:
         with:
           terraform_version: ${{ matrix.terraform-version }}
           terraform_wrapper: false
-      - run: make testacc TESTARGS="-run=TestAccResourceVmcSddc_Zerocloud"
+      - run: make testacc TESTARGS="-run='TestAccResourceVmcSddcZerocloud|TestAccResourceVmcClusterZerocloud|TestAccResourceVmcSiteRecoveryZerocloud|TestAccResourceVmcSrmNodeZerocloud|TestAccDataSourceVmcCustomerSubnetsBasic' -parallel 4"
         env:
           TF_ACC: '1'
           API_TOKEN: ${{ secrets.API_TOKEN }}

--- a/vmc/data_source_vmc_customer_subnets_test.go
+++ b/vmc/data_source_vmc_customer_subnets_test.go
@@ -1,4 +1,4 @@
-/* Copyright 2019 VMware, Inc.
+/* Copyright 2019-2022 VMware, Inc.
    SPDX-License-Identifier: MPL-2.0 */
 
 package vmc
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAccDataSourceVmcCustomerSubnetsBasic(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheckZerocloud(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{

--- a/vmc/resource_vmc_cluster_test.go
+++ b/vmc/resource_vmc_cluster_test.go
@@ -50,7 +50,7 @@ func TestAccResourceVmcClusterZerocloud(t *testing.T) {
 	clusterRef := "cluster_zerocloud"
 	resourceName := "vmc_cluster." + clusterRef
 	sddcName := "terraform_test_sddc_" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckZerocloud(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckVmcClusterDestroy,
@@ -114,7 +114,6 @@ func testAccCheckVmcClusterExists(clusterRef string, sddcResource *model.Sddc) r
 }
 
 func testCheckVmcClusterDestroy(s *terraform.State) error {
-
 	connectorWrapper := testAccProvider.Meta().(*ConnectorWrapper)
 	connector := connectorWrapper.Connector
 	sddcClient := orgs.NewSddcsClient(connector)
@@ -125,12 +124,13 @@ func testCheckVmcClusterDestroy(s *terraform.State) error {
 		}
 
 		sddcID := rs.Primary.Attributes["sddc_id"]
+		clusterId := rs.Primary.Attributes["id"]
 		orgID := connectorWrapper.OrgID
 		sddcResource, err := sddcClient.Get(orgID, sddcID)
 
 		for i := 0; i < len(sddcResource.ResourceConfig.Clusters); i++ {
 			currentResourceConfig := sddcResource.ResourceConfig.Clusters[i]
-			if strings.Contains(*currentResourceConfig.ClusterName, "Cluster-2") {
+			if currentResourceConfig.ClusterId == clusterId {
 				return fmt.Errorf("cluster still exists : %v", err)
 			}
 		}

--- a/vmc/resource_vmc_sddc_test.go
+++ b/vmc/resource_vmc_sddc_test.go
@@ -1,4 +1,4 @@
-/* Copyright 2019 VMware, Inc.
+/* Copyright 2019-2022 VMware, Inc.
    SPDX-License-Identifier: MPL-2.0 */
 
 package vmc
@@ -42,10 +42,10 @@ func TestAccResourceVmcSddc_basic(t *testing.T) {
 	})
 }
 
-func TestAccResourceVmcSddc_Zerocloud(t *testing.T) {
+func TestAccResourceVmcSddcZerocloud(t *testing.T) {
 	var sddcResource model.Sddc
 	sddcName := "terraform_test_sddc_" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckZerocloud(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckVmcSddcDestroy,

--- a/vmc/utils.go
+++ b/vmc/utils.go
@@ -1,4 +1,4 @@
-/* Copyright 2020 VMware, Inc.
+/* Copyright 2020-2022 VMware, Inc.
    SPDX-License-Identifier: MPL-2.0 */
 
 package vmc
@@ -40,9 +40,9 @@ func ConvertStorageCapacitytoInt(s string) int64 {
 // to maintain consistency
 func ConvertDeployType(s string) string {
 	if s == "SINGLE_AZ" {
-		return "SingleAZ"
+		return SingleAvailabilityZone
 	} else if s == "MULTI_AZ" {
-		return "MultiAZ"
+		return MultiAvailabilityZone
 	} else {
 		return ""
 	}
@@ -94,15 +94,14 @@ func getNSXTReverseProxyURLConnector(nsxtReverseProxyUrl string) (client.Connect
 // the ResourceConfig of the provided SDDC. If there is no ResourceConfig/Cluster 0 is returned.
 // A Cluster is distinguished by its id
 func getHostCountCluster(sddc *model.Sddc, clusterId string) int {
-	clusterHostCount := 0
 	if sddc != nil && sddc.ResourceConfig != nil && sddc.ResourceConfig.Clusters != nil {
 		for _, cluster := range sddc.ResourceConfig.Clusters {
 			if cluster.ClusterId == clusterId {
-				clusterHostCount += len(cluster.EsxHostList)
+				return len(cluster.EsxHostList)
 			}
 		}
 	}
-	return clusterHostCount
+	return 0
 }
 
 // toHostInstanceType converts from the Schema format of the host_instance_type to


### PR DESCRIPTION
…stomer Subnets in parallel

Few notes:
SRM and SRM Node resources on Zerocloud do not feature a "vm_moref_id", hence the nil checks. SRM and SRM destroy checks use both "deactivated" and "deleted" state as valid destroyed states (API returns one of either) Cluster destroy check now uses ID instead of name comparison.

Testing done:
make build
make test
golangci-lint run

Performed 4 time successfully:
make testacc TESTARGS="-run='TestAccResourceVmcSddcZerocloud|TestAccResourceVmcSrmNodeZerocloud|TestAccResourceVmcClusterZerocloud|TestAccResourceVmcSiteRecoveryZerocloud|TestAccDataSourceVmcCustomerSubnetsBasic' -parallel 4"

Signed-off-by: Dimitar Proynov <proynovd@vmware.com>