### PR TITLE
Add E2E tests for Import SDDC, Import Org and AWS connected accounts

### DIFF
--- a/.github/workflows/acceptance_tests_lite.yaml
+++ b/.github/workflows/acceptance_tests_lite.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           terraform_version: ${{ matrix.terraform-version }}
           terraform_wrapper: false
-      - run: make testacc TESTARGS="-run='TestAccResourceVmcSddcZerocloud|TestAccResourceVmcClusterZerocloud|TestAccResourceVmcSiteRecoveryZerocloud|TestAccResourceVmcSrmNodeZerocloud|TestAccDataSourceVmcCustomerSubnetsBasic' -parallel 4"
+      - run: make testacc TESTARGS="-run='TestAccResourceVmcSddcZerocloud|TestAccResourceVmcClusterZerocloud|TestAccResourceVmcSiteRecoveryZerocloud|TestAccResourceVmcSrmNodeZerocloud|TestAccDataSourceVmcCustomerSubnetsBasic|TestAccDataSourceVmcConnectedAccountsBasic|TestAccDataSourceVmcOrgBasic|TestAccDataSourceVmcSddcBasic' -parallel 4"
         env:
           TF_ACC: '1'
           API_TOKEN: ${{ secrets.API_TOKEN }}

--- a/vmc/data_source_vmc_connected_accounts_test.go
+++ b/vmc/data_source_vmc_connected_accounts_test.go
@@ -1,4 +1,4 @@
-/* Copyright 2019 VMware, Inc.
+/* Copyright 2019-2022 VMware, Inc.
    SPDX-License-Identifier: MPL-2.0 */
 
 package vmc
@@ -11,9 +11,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccDataSourceVmcConnectedAccounts_basic(t *testing.T) {
+func TestAccDataSourceVmcConnectedAccountsBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckZerocloud(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/vmc/data_source_vmc_org_test.go
+++ b/vmc/data_source_vmc_org_test.go
@@ -1,4 +1,4 @@
-/* Copyright 2019 VMware, Inc.
+/* Copyright 2019-2022 VMware, Inc.
    SPDX-License-Identifier: MPL-2.0 */
 
 package vmc
@@ -10,9 +10,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccDataSourceVmcOrg_basic(t *testing.T) {
+func TestAccDataSourceVmcOrgBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckZerocloud(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/vmc/resource_vmc_cluster.go
+++ b/vmc/resource_vmc_cluster.go
@@ -109,9 +109,9 @@ func resourceClusterCreate(d *schema.ResourceData, m interface{}) error {
 			}
 			d.SetId(clusterID)
 		}
-		if *task.Status == "FAILED" {
-			return resource.NonRetryableError(fmt.Errorf("task failed to create cluster"))
-		} else if *task.Status != "FINISHED" {
+		if *task.Status == model.Task_STATUS_FAILED {
+			return resource.NonRetryableError(fmt.Errorf("task failed to create cluster: %s", *task.ErrorMessage))
+		} else if *task.Status != model.Task_STATUS_FINISHED {
 			return resource.RetryableError(fmt.Errorf("expected cluster to be created but was in state %s", *task.Status))
 		}
 		err = resourceClusterRead(d, m)
@@ -199,9 +199,9 @@ func resourceClusterDelete(d *schema.ResourceData, m interface{}) error {
 		if err != nil {
 			return resource.NonRetryableError(fmt.Errorf("error deleting cluster %s : %v", clusterID, err))
 		}
-		if *task.Status == "FAILED" {
-			return resource.NonRetryableError(fmt.Errorf("task failed to delete cluster"))
-		} else if *task.Status != "FINISHED" {
+		if *task.Status == model.Task_STATUS_FAILED {
+			return resource.NonRetryableError(fmt.Errorf("task failed to delete cluster %s", *task.ErrorMessage))
+		} else if *task.Status != model.Task_STATUS_FINISHED {
 			return resource.RetryableError(fmt.Errorf("expected cluster to be deleted but was in state %s", *task.Status))
 		}
 		d.SetId("")
@@ -246,9 +246,9 @@ func resourceClusterUpdate(d *schema.ResourceData, m interface{}) error {
 			if err != nil {
 				return resource.NonRetryableError(fmt.Errorf("error updating hosts for cluster : %v", err))
 			}
-			if *task.Status == "FAILED" {
-				return resource.NonRetryableError(fmt.Errorf("task failed to update hosts for cluster"))
-			} else if *task.Status != "FINISHED" {
+			if *task.Status == model.Task_STATUS_FAILED {
+				return resource.NonRetryableError(fmt.Errorf("task failed to update hosts for cluster: %s", *task.ErrorMessage))
+			} else if *task.Status != model.Task_STATUS_FINISHED {
 				return resource.RetryableError(fmt.Errorf("expected hosts to be updated but was in state %s", *task.Status))
 			}
 			err = resourceClusterRead(d, m)
@@ -294,9 +294,9 @@ func resourceClusterUpdate(d *schema.ResourceData, m interface{}) error {
 				}
 				return resource.NonRetryableError(fmt.Errorf("error updating EDRS policy configuration : %v", err))
 			}
-			if *task.Status == "FAILED" {
-				return resource.NonRetryableError(fmt.Errorf("task failed to update EDRS policy configuration"))
-			} else if *task.Status != "FINISHED" {
+			if *task.Status == model.Task_STATUS_FAILED {
+				return resource.NonRetryableError(fmt.Errorf("task failed to update EDRS policy configuration: %s", *task.ErrorMessage))
+			} else if *task.Status != model.Task_STATUS_FINISHED {
 				return resource.RetryableError(fmt.Errorf("expected EDRS policy configuration to be updated but was in state %s", *task.Status))
 			}
 			err = resourceClusterRead(d, m)
@@ -328,10 +328,12 @@ func resourceClusterUpdate(d *schema.ResourceData, m interface{}) error {
 				}
 				return resource.NonRetryableError(fmt.Errorf("error updating microsoft licensing configuration : %v", err))
 			}
-			if *task.Status == "FAILED" {
-				return resource.NonRetryableError(fmt.Errorf("task failed to update microsoft licensing configuration"))
-			} else if *task.Status != "FINISHED" {
-				return resource.RetryableError(fmt.Errorf("expected microsoft licensing configuration to be updated but was in state %s", *task.Status))
+			if *task.Status == model.Task_STATUS_FAILED {
+				return resource.NonRetryableError(
+					fmt.Errorf("task failed to update microsoft licensing configuration %s", *task.ErrorMessage))
+			} else if *task.Status != model.Task_STATUS_FINISHED {
+				return resource.RetryableError(
+					fmt.Errorf("expected microsoft licensing configuration to be updated but was in state %s", *task.Status))
 			}
 			err = resourceClusterRead(d, m)
 			if err == nil {


### PR DESCRIPTION
Additionally, improve debuggability of Cluster operations by printing Error if tasks fail.

Testing done:
make build
make test
golangci-lint run

make testacc TESTARGS="-run=TestAccDataSourceVmcSddcBasic" --- PASS: TestAccDataSourceVmcSddcBasic (5.19s)
PASS
ok  	github.com/vmware/terraform-provider-vmc/vmc	5.480s

make testacc TESTARGS="-run=TestAccDataSourceVmcOrgBasic" --- PASS: TestAccDataSourceVmcOrgBasic (4.58s)
PASS
ok  	github.com/vmware/terraform-provider-vmc/vmc	5.550s

make testacc TESTARGS="-run=TestAccDataSourceVmcConnectedAccountsBasic" --- PASS: TestAccDataSourceVmcConnectedAccountsBasic (5.08s) PASS
ok  	github.com/vmware/terraform-provider-vmc/vmc	5.964s

Signed-off-by: Dimitar Proynov <proynovd@vmware.com>