### PR TITLE
Remove restrictions on MultiAZ SDDCs from provider

### DIFF
--- a/vmc/constants/constants.go
+++ b/vmc/constants/constants.go
@@ -25,7 +25,6 @@ const (
 	// Availability Zones
 	SingleAvailabilityZone string = "SingleAZ"
 	MultiAvailabilityZone  string = "MultiAZ"
-	MinMultiAZHosts        int    = 6
 
 	// SDDC Size
 	MediumSddcSize        = "medium"

--- a/vmc/resource_vmc_sddc.go
+++ b/vmc/resource_vmc_sddc.go
@@ -42,13 +42,6 @@ func resourceSddc() *schema.Resource {
 		},
 		Schema: sddcSchema(),
 		CustomizeDiff: func(c context.Context, d *schema.ResourceDiff, meta interface{}) error {
-			deploymentType := d.Get("deployment_type").(string)
-			numHosts := d.Get("num_host").(int)
-
-			if deploymentType == constants.MultiAvailabilityZone && numHosts < constants.MinMultiAZHosts {
-				return fmt.Errorf("for MulitAZ deployment type number of hosts must be atleast %d ", constants.MinMultiAZHosts)
-			}
-
 			newInstanceType := d.Get("host_instance_type").(string)
 			switch newInstanceType {
 			case constants.HostInstancetypeI3, constants.HostInstancetypeI3EN, constants.HostInstancetypeI4I:


### PR DESCRIPTION
The restrictions are redundant and out of sync with the VMC backend. The minimum number of hosts in a MultiAZ SDDC is controlled by a property in the CSP Org of the customer. Having another check for the minimum number of hosts in the provider restricts the user from deploying a MultiAZ SDDC with 2 or 4 hosts, which may be allowed in the VMC UI.

If the minimum number of hosts in the Customer CSP ORG is still 6, the SDDC deployment will fail with a backend error:

Error:  Failed to create SDDC: [Sddc provisioning requires a minimum of 4 hosts. (code)115 ]

So there is no adverse functional impact of this change.

https://github.com/vmware/terraform-provider-vmc/issues/166
https://github.com/vmware/terraform-provider-vmc/issues/168

Testing done:
make build
make test
golangci-lint run

Successfully deployed MultiAZ SDDC with num_host=2

Signed-off-by: Dimitar Proynov <proynovd@vmware.com>