### PR TITLE
Add support for OAuth2.0 server-to-server authentication

### DIFF
--- a/.github/workflows/acceptance_tests_lite.yaml
+++ b/.github/workflows/acceptance_tests_lite.yaml
@@ -30,7 +30,8 @@ jobs:
       - run: make testacc TESTARGS="-run='TestAccResourceVmcSddcZerocloud|TestAccResourceVmcClusterZerocloud|TestAccResourceVmcSiteRecoveryZerocloud|TestAccResourceVmcSrmNodeZerocloud|TestAccDataSourceVmcCustomerSubnetsBasic|TestAccDataSourceVmcConnectedAccountsBasic|TestAccDataSourceVmcOrgBasic|TestAccDataSourceVmcSddcBasic|TestAccResourceSddcGroupZerocloud' -parallel 4"
         env:
           TF_ACC: '1'
-          API_TOKEN: ${{ secrets.API_TOKEN }}
+          CLIENT_ID: ${{ secrets.CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           AWS_ACCOUNT_NUMBER: ${{ secrets.AWS_ACCOUNT_NUMBER }}
           CSP_URL: ${{ secrets.CSP_URL }}
           ORG_DISPLAY_NAME: ${{ secrets.ORG_DISPLAY_NAME }}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/vmware/vsphere-automation-sdk-go/services/vmc v0.10.0
 	github.com/vmware/vsphere-automation-sdk-go/services/vmc/autoscaler v0.4.0
 	github.com/vmware/vsphere-automation-sdk-go/services/vmc/draas v0.4.0
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -285,6 +285,7 @@ golang.org/x/net v0.0.0-20210510120150-4163338589ed h1:p9UgmWI9wKpfYmgaV/IZKGdXc
 golang.org/x/net v0.0.0-20210510120150-4163338589ed/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:TzXSXBo42m9gQenoE3b9BGiEpg5IG2JkU5FkPIawgtw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/vmc/connector/clientconnector.go
+++ b/vmc/connector/clientconnector.go
@@ -5,6 +5,7 @@
 package connector
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -26,23 +27,46 @@ type Authenticator interface {
 type Wrapper struct {
 	client.Connector
 	RefreshToken string
+	ClientID     string
+	ClientSecret string
 	OrgID        string
 	VmcURL       string
 	CspURL       string
 }
 
+func CopyWrapper(original Wrapper) *Wrapper {
+	return &Wrapper{
+		RefreshToken: original.RefreshToken,
+		ClientID:     original.ClientID,
+		ClientSecret: original.ClientSecret,
+		OrgID:        original.OrgID,
+		VmcURL:       original.VmcURL,
+		CspURL:       original.CspURL,
+	}
+}
+
 func (c *Wrapper) Authenticate() error {
 	var err error
 	httpClient := http.Client{}
-	c.Connector, err = NewClientConnectorByRefreshToken(c.RefreshToken, c.VmcURL, c.CspURL, httpClient)
-	if err != nil {
-		return err
+	if len(c.RefreshToken) > 0 {
+		c.Connector, err = newClientConnectorByRefreshToken(c.RefreshToken, c.VmcURL, c.CspURL, httpClient)
+		if err != nil {
+			return err
+		}
+		return nil
 	}
-	return nil
+	if len(c.ClientID) > 0 && len(c.ClientSecret) > 0 {
+		c.Connector, err = newClientConnectorByClientID(c.ClientID, c.ClientSecret, c.VmcURL, c.CspURL, httpClient)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	return fmt.Errorf("no refreshToken or ClientID/ClientSecret provided")
 }
 
-// NewClientConnectorByRefreshToken returns client connector to any VMC service by using OAuth authentication using Refresh Token.
-func NewClientConnectorByRefreshToken(refreshToken, serviceURL, cspURL string,
+// newClientConnectorByRefreshToken returns client connector to any VMC service by using OAuth authentication using Refresh Token.
+func newClientConnectorByRefreshToken(refreshToken, serviceURL, cspURL string,
 	httpClient http.Client) (client.Connector, error) {
 
 	if len(serviceURL) <= 0 {
@@ -57,7 +81,7 @@ func NewClientConnectorByRefreshToken(refreshToken, serviceURL, cspURL string,
 			constants.CspRefreshURLSuffix
 	}
 
-	securityCtx, err := SecurityContextByRefreshToken(refreshToken, cspURL)
+	securityCtx, err := securityContextByRefreshToken(refreshToken, cspURL)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +93,7 @@ func NewClientConnectorByRefreshToken(refreshToken, serviceURL, cspURL string,
 }
 
 // SecurityContextByRefreshToken returns Security Context with access token that is received from Cloud Service Provider using Refresh Token by OAuth authentication scheme.
-func SecurityContextByRefreshToken(refreshToken string, cspURL string) (core.SecurityContext, error) {
+func securityContextByRefreshToken(refreshToken string, cspURL string) (core.SecurityContext, error) {
 	payload := strings.NewReader("refresh_token=" + refreshToken)
 
 	req, _ := http.NewRequest("POST", cspURL, payload)
@@ -82,15 +106,74 @@ func SecurityContextByRefreshToken(refreshToken string, cspURL string) (core.Sec
 		return nil, err
 	}
 
-	if res.StatusCode != 200 {
-		b, _ := io.ReadAll(res.Body)
-		return nil, fmt.Errorf("response from Cloud Service Provider contains status code %d : %s", res.StatusCode, string(b))
+	securityCtx, err := parseAuthnResponse(res)
+	if err != nil {
+		return nil, err
+	}
+	return securityCtx, nil
+}
+
+// newClientConnectorByClientID returns client connector to any VMC service by using OAuth authentication using clientId and secret.
+func newClientConnectorByClientID(clientID, clientSecret, serviceURL, cspURL string,
+	httpClient http.Client) (client.Connector, error) {
+
+	if len(serviceURL) <= 0 {
+		serviceURL = constants.DefaultVmcURL
 	}
 
-	defer res.Body.Close()
+	if len(cspURL) <= 0 {
+		cspURL = constants.DefaultCspURL +
+			constants.CspOauthURLSuffix
+	} else {
+		cspURL = cspURL +
+			constants.CspOauthURLSuffix
+	}
+
+	securityCtx, err := securityContextByClientID(clientID, clientSecret, cspURL)
+	if err != nil {
+		return nil, err
+	}
+
+	connector := client.NewRestConnector(serviceURL, httpClient)
+	connector.SetSecurityContext(securityCtx)
+
+	return connector, nil
+}
+
+func securityContextByClientID(clientID string, clientSecret string, cspURL string) (core.SecurityContext, error) {
+	clientCredentials := clientID + ":" + clientSecret
+	encodedClientCredentials := base64.StdEncoding.EncodeToString([]byte(clientCredentials))
+
+	payload := strings.NewReader("grant_type=client_credentials")
+
+	req, _ := http.NewRequest("POST", cspURL, payload)
+
+	req.Header.Add("content-type", "application/x-www-form-urlencoded")
+	req.Header.Add("authorization", "Basic "+encodedClientCredentials)
+
+	res, err := http.DefaultClient.Do(req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	securityCtx, err := parseAuthnResponse(res)
+	if err != nil {
+		return nil, err
+	}
+	return securityCtx, nil
+}
+
+func parseAuthnResponse(response *http.Response) (*security.OauthSecurityContext, error) {
+	if response.StatusCode != 200 {
+		b, _ := io.ReadAll(response.Body)
+		return nil, fmt.Errorf("response from Cloud Service Provider contains status code %d : %s", response.StatusCode, string(b))
+	}
+
+	defer response.Body.Close()
 
 	var jsondata map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&jsondata)
+	err := json.NewDecoder(response.Body).Decode(&jsondata)
 	if err != nil {
 		return nil, fmt.Errorf("error decoding response : %v", err)
 	}
@@ -104,7 +187,7 @@ func SecurityContextByRefreshToken(refreshToken string, cspURL string) (core.Sec
 			return nil, errors.New(errMsg)
 		}
 	} else {
-		return nil, errors.New("Cloud Service Provider authentication response does not contain access token")
+		return nil, errors.New("cloud Service Provider authentication response does not contain access token")
 	}
 
 	securityCtx := security.NewOauthSecurityContext(accessToken)

--- a/vmc/constants/constants.go
+++ b/vmc/constants/constants.go
@@ -13,8 +13,8 @@ const (
 	// CspRefreshURLSuffix defines the CSP Refresh Token API endpoint.
 	CspRefreshURLSuffix string = "/csp/gateway/am/api/auth/api-tokens/authorize"
 
-	// CspOauthURLSuffix defines the CSP Oauth API endpoint.
-	CspOauthURLSuffix string = "/csp/gateway/am/api/auth/token"
+	// CspTokenURLSuffix defines the CSP Oauth API endpoint.
+	CspTokenURLSuffix string = "/csp/gateway/am/api/auth/token"
 
 	// sksNSXTManager to be stripped from nsxt reverse proxy url for public IP resource
 	SksNSXTManager string = "/sks-nsxt-manager"

--- a/vmc/constants/constants.go
+++ b/vmc/constants/constants.go
@@ -10,8 +10,11 @@ const (
 	// DefaultCspURL defines the default URL for CSP.
 	DefaultCspURL string = "https://console.cloud.vmware.com"
 
-	// CspRefreshURLSuffix defines the CSP Refresh API endpoint.
+	// CspRefreshURLSuffix defines the CSP Refresh Token API endpoint.
 	CspRefreshURLSuffix string = "/csp/gateway/am/api/auth/api-tokens/authorize"
+
+	// CspOauthURLSuffix defines the CSP Oauth API endpoint.
+	CspOauthURLSuffix string = "/csp/gateway/am/api/auth/token"
 
 	// sksNSXTManager to be stripped from nsxt reverse proxy url for public IP resource
 	SksNSXTManager string = "/sks-nsxt-manager"
@@ -68,6 +71,8 @@ const (
 	VmcURL         string = "VMC_URL"
 	CspURL         string = "CSP_URL"
 	APIToken       string = "API_TOKEN"
+	ClientID       string = "CLIENT_ID"
+	ClientSecret   string = "CLIENT_SECRET"
 	OrgID          string = "ORG_ID"
 	OrgDisplayName string = "ORG_DISPLAY_NAME"
 	// TestSddcID ID of an existing SDDC used for sddc data source, site recovery and srm node tests

--- a/vmc/data_source_vmc_sddc.go
+++ b/vmc/data_source_vmc_sddc.go
@@ -212,9 +212,14 @@ func dataSourceVmcSddcRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("nsxt_ui", *sddc.ResourceConfig.Nsxt)
 		if sddc.ResourceConfig.NsxCloudAdmin != nil {
 			d.Set("nsxt_cloudadmin", *sddc.ResourceConfig.NsxCloudAdmin)
-			d.Set("nsxt_cloudadmin_password", *sddc.ResourceConfig.NsxCloudAdminPassword)
+			// Evade nil pointer dereference when user's access_token doesn't have NSX roles
+			if sddc.ResourceConfig.NsxCloudAdminPassword != nil {
+				_ = d.Set("nsxt_cloudadmin_password", *sddc.ResourceConfig.NsxCloudAdminPassword)
+			}
+			if sddc.ResourceConfig.NsxCloudAuditPassword != nil {
+				_ = d.Set("nsxt_cloudaudit_password", *sddc.ResourceConfig.NsxCloudAuditPassword)
+			}
 			d.Set("nsxt_cloudaudit", *sddc.ResourceConfig.NsxCloudAudit)
-			d.Set("nsxt_cloudaudit_password", *sddc.ResourceConfig.NsxCloudAuditPassword)
 			d.Set("nsxt_private_ip", *sddc.ResourceConfig.NsxMgrManagementIp)
 			d.Set("nsxt_private_url", *sddc.ResourceConfig.NsxMgrLoginUrl)
 		}

--- a/vmc/provider_test.go
+++ b/vmc/provider_test.go
@@ -67,8 +67,11 @@ func testAccPreCheckZerocloud(t *testing.T) {
 	if v := os.Getenv(constants.CspURL); v == "" {
 		t.Fatal(constants.CspURL + " must be set for Zerocloud acceptance tests")
 	}
-	if v := os.Getenv(constants.APIToken); v == "" {
-		t.Fatal(constants.APIToken + " must be set for acceptance tests")
+	if v := os.Getenv(constants.ClientID); v == "" {
+		t.Fatal(constants.ClientID + " must be set for acceptance tests")
+	}
+	if v := os.Getenv(constants.ClientSecret); v == "" {
+		t.Fatal(constants.ClientSecret + " must be set for acceptance tests")
 	}
 	if v := os.Getenv(constants.OrgID); v == "" {
 		t.Fatal(constants.OrgID + " must be set for acceptance tests")

--- a/vmc/resource_vmc_public_ip.go
+++ b/vmc/resource_vmc_public_ip.go
@@ -5,6 +5,7 @@ package vmc
 
 import (
 	"fmt"
+	"github.com/vmware/terraform-provider-vmc/vmc/connector"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -59,7 +60,8 @@ func resourcePublicIP() *schema.Resource {
 
 func resourcePublicIPCreate(d *schema.ResourceData, m interface{}) error {
 	nsxtReverseProxyURL := d.Get("nsxt_reverse_proxy_url").(string)
-	connector, err := getNsxtReverseProxyURLConnector(nsxtReverseProxyURL)
+	connectorWrapper := m.(*connector.Wrapper)
+	connector, err := getNsxtReverseProxyURLConnector(nsxtReverseProxyURL, connectorWrapper)
 	if err != nil {
 		return HandleCreateError("NSXT reverse proxy URL connector", err)
 	}
@@ -87,7 +89,8 @@ func resourcePublicIPCreate(d *schema.ResourceData, m interface{}) error {
 
 func resourcePublicIPRead(d *schema.ResourceData, m interface{}) error {
 	nsxtReverseProxyURL := d.Get("nsxt_reverse_proxy_url").(string)
-	connector, err := getNsxtReverseProxyURLConnector(nsxtReverseProxyURL)
+	connectorWrapper := m.(*connector.Wrapper)
+	connector, err := getNsxtReverseProxyURLConnector(nsxtReverseProxyURL, connectorWrapper)
 	if err != nil {
 		return HandleCreateError("NSXT reverse proxy URL connector", err)
 	}
@@ -124,7 +127,8 @@ func resourcePublicIPRead(d *schema.ResourceData, m interface{}) error {
 
 func resourcePublicIPUpdate(d *schema.ResourceData, m interface{}) error {
 	nsxtReverseProxyURL := d.Get("nsxt_reverse_proxy_url").(string)
-	connector, err := getNsxtReverseProxyURLConnector(nsxtReverseProxyURL)
+	connectorWrapper := m.(*connector.Wrapper)
+	connector, err := getNsxtReverseProxyURLConnector(nsxtReverseProxyURL, connectorWrapper)
 	if err != nil {
 		return HandleCreateError("NSXT reverse proxy URL connector", err)
 	}
@@ -154,7 +158,8 @@ func resourcePublicIPUpdate(d *schema.ResourceData, m interface{}) error {
 
 func resourcePublicIPDelete(d *schema.ResourceData, m interface{}) error {
 	nsxtReverseProxyURL := d.Get("nsxt_reverse_proxy_url").(string)
-	connector, err := getNsxtReverseProxyURLConnector(nsxtReverseProxyURL)
+	connectorWrapper := m.(*connector.Wrapper)
+	connector, err := getNsxtReverseProxyURLConnector(nsxtReverseProxyURL, connectorWrapper)
 	if err != nil {
 		return HandleCreateError("NSXT reverse proxy URL connector", err)
 	}

--- a/vmc/resource_vmc_sddc.go
+++ b/vmc/resource_vmc_sddc.go
@@ -401,10 +401,10 @@ func resourceSddcCreate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceSddcRead(d *schema.ResourceData, m interface{}) error {
-	connectorWrapper := (m.(*connector.Wrapper)).Connector
+	connectorWrapper := m.(*connector.Wrapper)
 	sddcID := d.Id()
 	orgID := (m.(*connector.Wrapper)).OrgID
-	sddc, err := GetSddc(connectorWrapper, orgID, sddcID)
+	sddc, err := GetSddc(connectorWrapper.Connector, orgID, sddcID)
 	if err != nil {
 		return HandleReadError(d, "SDDC", sddcID, err)
 	}
@@ -435,7 +435,7 @@ func resourceSddcRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("account_link_state", sddc.AccountLinkState)
 	d.Set("sddc_access_state", sddc.SddcAccessState)
 	d.Set("sddc_state", sddc.SddcState)
-	primaryClusterClient := sddcs.NewPrimaryclusterClient(connectorWrapper)
+	primaryClusterClient := sddcs.NewPrimaryclusterClient(connectorWrapper.Connector)
 	primaryCluster, err := primaryClusterClient.Get(orgID, sddcID)
 	if err != nil {
 		return HandleReadError(d, "Primary Cluster", sddcID, err)
@@ -488,7 +488,7 @@ func resourceSddcRead(d *schema.ResourceData, m interface{}) error {
 			d.Set("nsxt_private_url", *sddc.ResourceConfig.NsxMgrLoginUrl)
 		}
 	}
-	edrsPolicyClient := autoscalercluster.NewEdrsPolicyClient(connectorWrapper)
+	edrsPolicyClient := autoscalercluster.NewEdrsPolicyClient(connectorWrapper.Connector)
 	edrsPolicy, err := edrsPolicyClient.Get(orgID, sddcID, primaryCluster.ClusterId)
 	if err != nil {
 		return HandleReadError(d, "SDDC", sddcID, err)
@@ -501,7 +501,7 @@ func resourceSddcRead(d *schema.ResourceData, m interface{}) error {
 	if *sddc.Provider != constants.ZeroCloudProviderType {
 		// store intranet_mtu_uplink only for non zerocloud provider types
 		nsxtReverseProxyURL := d.Get("nsxt_reverse_proxy_url").(string)
-		nsxtReverseProxyURLConnector, err := getNsxtReverseProxyURLConnector(nsxtReverseProxyURL)
+		nsxtReverseProxyURLConnector, err := getNsxtReverseProxyURLConnector(nsxtReverseProxyURL, connectorWrapper)
 		if err != nil {
 			return HandleCreateError("NSXT reverse proxy URL connectorWrapper", err)
 		}
@@ -659,7 +659,7 @@ func resourceSddcUpdate(d *schema.ResourceData, m interface{}) error {
 		}
 		intranetMTUUplink := d.Get("intranet_mtu_uplink").(int)
 		nsxtReverseProxyURL := d.Get("nsxt_reverse_proxy_url").(string)
-		nxstReverseProxyURLConnector, err := getNsxtReverseProxyURLConnector(nsxtReverseProxyURL)
+		nxstReverseProxyURLConnector, err := getNsxtReverseProxyURLConnector(nsxtReverseProxyURL, connectorWrapper)
 		if err != nil {
 			return HandleCreateError("NSXT reverse proxy URL connector", err)
 		}

--- a/vmc/resource_vmc_sddc.go
+++ b/vmc/resource_vmc_sddc.go
@@ -474,9 +474,14 @@ func resourceSddcRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("sddc_size", sddcSizeInfo)
 		if sddc.ResourceConfig.NsxCloudAdmin != nil {
 			d.Set("nsxt_cloudadmin", *sddc.ResourceConfig.NsxCloudAdmin)
-			d.Set("nsxt_cloudadmin_password", *sddc.ResourceConfig.NsxCloudAdminPassword)
+			// Evade nil pointer dereference when user's access_token doesn't have NSX roles
+			if sddc.ResourceConfig.NsxCloudAdminPassword != nil {
+				_ = d.Set("nsxt_cloudadmin_password", *sddc.ResourceConfig.NsxCloudAdminPassword)
+			}
+			if sddc.ResourceConfig.NsxCloudAuditPassword != nil {
+				_ = d.Set("nsxt_cloudaudit_password", *sddc.ResourceConfig.NsxCloudAuditPassword)
+			}
 			d.Set("nsxt_cloudaudit", *sddc.ResourceConfig.NsxCloudAudit)
-			d.Set("nsxt_cloudaudit_password", *sddc.ResourceConfig.NsxCloudAuditPassword)
 			d.Set("nsxt_private_ip", *sddc.ResourceConfig.NsxMgrManagementIp)
 			d.Set("nsxt_private_url", *sddc.ResourceConfig.NsxMgrLoginUrl)
 		}

--- a/vmc/resource_vmc_sddc_group.go
+++ b/vmc/resource_vmc_sddc_group.go
@@ -169,8 +169,7 @@ func sddcGroupSchema() map[string]*schema.Schema {
 
 func resourceSddcGroupCreate(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
 	connectorWrapper := i.(*connector.Wrapper)
-	sddcGroupsClient := sddcgroup.NewSddcGroupClient(connectorWrapper.VmcURL, connectorWrapper.CspURL,
-		connectorWrapper.RefreshToken, connectorWrapper.OrgID)
+	sddcGroupsClient := sddcgroup.NewSddcGroupClient(*connectorWrapper)
 	err := sddcGroupsClient.Authenticate()
 	if err != nil {
 		return diag.FromErr(err)
@@ -208,8 +207,7 @@ func resourceSddcGroupCreate(ctx context.Context, data *schema.ResourceData, i i
 
 func resourceSddcGroupRead(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
 	connectorWrapper := i.(*connector.Wrapper)
-	sddcGroupsClient := sddcgroup.NewSddcGroupClient(connectorWrapper.VmcURL, connectorWrapper.CspURL,
-		connectorWrapper.RefreshToken, connectorWrapper.OrgID)
+	sddcGroupsClient := sddcgroup.NewSddcGroupClient(*connectorWrapper)
 	err := sddcGroupsClient.Authenticate()
 	if err != nil {
 		return diag.FromErr(err)
@@ -284,8 +282,7 @@ func resourceSddcGroupUpdate(ctx context.Context, data *schema.ResourceData, i i
 
 func resourceSddcGroupDelete(_ context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
 	connectorWrapper := i.(*connector.Wrapper)
-	sddcGroupsClient := sddcgroup.NewSddcGroupClient(connectorWrapper.VmcURL, connectorWrapper.CspURL,
-		connectorWrapper.RefreshToken, connectorWrapper.OrgID)
+	sddcGroupsClient := sddcgroup.NewSddcGroupClient(*connectorWrapper)
 	err := sddcGroupsClient.Authenticate()
 	if err != nil {
 		return diag.FromErr(err)
@@ -320,8 +317,7 @@ func resourceSddcGroupDelete(_ context.Context, data *schema.ResourceData, i int
 func updateSddcGroupMembers(data *schema.ResourceData,
 	i interface{}, addedIds *[]string, removedIds *[]string) diag.Diagnostics {
 	connectorWrapper := i.(*connector.Wrapper)
-	sddcGroupsClient := sddcgroup.NewSddcGroupClient(connectorWrapper.VmcURL, connectorWrapper.CspURL,
-		connectorWrapper.RefreshToken, connectorWrapper.OrgID)
+	sddcGroupsClient := sddcgroup.NewSddcGroupClient(*connectorWrapper)
 	err := sddcGroupsClient.Authenticate()
 	if err != nil {
 		return diag.FromErr(err)

--- a/vmc/resource_vmc_sddc_group_test.go
+++ b/vmc/resource_vmc_sddc_group_test.go
@@ -55,8 +55,7 @@ func testSddcGroupExists(s *terraform.State) error {
 
 func sddcGroupExists(s *terraform.State) bool {
 	connectorWrapper := testAccProvider.Meta().(*connector.Wrapper)
-	sddcGroupClient := sddcgroup.NewSddcGroupClient(connectorWrapper.VmcURL,
-		connectorWrapper.CspURL, connectorWrapper.RefreshToken, connectorWrapper.OrgID)
+	sddcGroupClient := sddcgroup.NewSddcGroupClient(*connectorWrapper)
 	err := sddcGroupClient.Authenticate()
 	if err != nil {
 		return false

--- a/vmc/resource_vmc_sddc_test.go
+++ b/vmc/resource_vmc_sddc_test.go
@@ -194,8 +194,8 @@ data "vmc_customer_subnets" "my_subnets" {
 
 resource "vmc_sddc" "sddc_zerocloud" {
 	sddc_name = %q
-	vpc_cidr      = "10.2.0.0/16"
-	num_host      = 3
+	vpc_cidr      = "10.40.0.0/16"
+	num_host      = 2
 	provider_type = "ZEROCLOUD"
 	host_instance_type = "I3_METAL"
 	region = "US_WEST_2"

--- a/vmc/task/task_convert.go
+++ b/vmc/task/task_convert.go
@@ -24,8 +24,7 @@ func GetTask(connectorWrapper *connector.Wrapper, taskID string) (model.Task, er
 
 // GetV2Task returns an adapted model.Task with specified ID
 func GetV2Task(connectorWrapper *connector.Wrapper, taskID string) (model.Task, error) {
-	tasksV2Client := NewV2ClientImpl(connectorWrapper.VmcURL, connectorWrapper.CspURL,
-		connectorWrapper.RefreshToken, connectorWrapper.OrgID)
+	tasksV2Client := NewV2ClientImpl(*connectorWrapper)
 	err := tasksV2Client.Authenticate()
 	if err != nil {
 		return model.Task{}, err


### PR DESCRIPTION
Added two new provider config properties: ClientID and ClientSecret that represent the credentials in OAuth2.0 client_credentials flow (server-to-server) and are in conflict with APIToken.

Implementation of OAuth2.0 App based authentication, based on prior work:
https://github.com/vmware/terraform-provider-vmc/pull/32

VMware, own docs:
https://developer.vmware.com/apis/csp/csp-iam/latest/csp/gateway/am/api/auth/token/post/

The change includes a major refactor to encapsulate all authentication logic into the connector.Wrapper struct, as different parts of authentication logic was leaking all over the place. Now the only place in the code where details about API_TOKEN or ClientID/ClientSecret are the Authenticate() method of connector.Wrapper.

Also converted Acceptance tests to run with ClientID and ClientSecret instead of my own APIToken. Since the test OAuth App runs with minimal priviledges some nil checks were added to reflect the API not returning some sensitive data (even if it is Zerocloud dummy data).

This is a new feature requested by customers and specifically StateStreet:
https://github.com/vmware/terraform-provider-vmc/issues/164

Testing done:
make build
make test

golangci-lint run

Full Acceptance tests successful run:
https://github.com/dimitarproynov/terraform-provider-vmc/actions/runs/4103883503/jobs/7078645332

