### PR TITLE
Introduce variables required by VMC backend for the specific test ORG used.

### DIFF
--- a/vmc/data_source_vmc_customer_subnets_test.go
+++ b/vmc/data_source_vmc_customer_subnets_test.go
@@ -43,6 +43,8 @@ data "vmc_connected_accounts" "my_accounts" {
 data "vmc_customer_subnets" "my_subnets" {
 	connected_account_id = data.vmc_connected_accounts.my_accounts.id
 	region = "US_WEST_2"
+	sddc_type = "SingleAZ"
+	instance_type = "i3.metal"
 }
 `,
 		os.Getenv(constants.AwsAccountNumber))

--- a/vmc/resource_vmc_cluster_test.go
+++ b/vmc/resource_vmc_cluster_test.go
@@ -157,6 +157,8 @@ data "vmc_connected_accounts" "my_accounts" {
 data "vmc_customer_subnets" "my_subnets" {
   connected_account_id = data.vmc_connected_accounts.my_accounts.id
   region               = "US_WEST_2"
+  sddc_type = "SingleAZ"
+  instance_type = "i3.metal"
 }
 
 resource "vmc_sddc" "sddc_1" {
@@ -207,6 +209,8 @@ data "vmc_connected_accounts" "my_accounts" {
 data "vmc_customer_subnets" "my_subnets" {
   connected_account_id = data.vmc_connected_accounts.my_accounts.id
   region               = "US_WEST_2"
+  sddc_type = "SingleAZ"
+  instance_type = "i3.metal"
 }
 
 resource "vmc_sddc" "sddc_zerocloud_cluster" {

--- a/vmc/resource_vmc_sddc_test.go
+++ b/vmc/resource_vmc_sddc_test.go
@@ -143,6 +143,8 @@ data "vmc_connected_accounts" "my_accounts" {
 data "vmc_customer_subnets" "my_subnets" {
   connected_account_id = data.vmc_connected_accounts.my_accounts.id
   region               = "US_WEST_2"
+  sddc_type = "SingleAZ"
+  instance_type = "i3.metal"
 }
 
 resource "vmc_sddc" "sddc_1" {
@@ -190,6 +192,8 @@ data "vmc_connected_accounts" "my_accounts" {
 data "vmc_customer_subnets" "my_subnets" {
   connected_account_id = data.vmc_connected_accounts.my_accounts.id
   region               = "US_WEST_2"
+  sddc_type = "SingleAZ"
+  instance_type = "i3.metal"
 }
 
 resource "vmc_sddc" "sddc_zerocloud" {


### PR DESCRIPTION
he requirement for the additional optional variables comes after a feature switch affecting the test Org was flipped.

Testing done:
make testacc TESTARGS="-run='TestAccResourceVmcSddcZerocloud|TestAccResourceVmcClusterZerocloud|TestAccResourceVmcSiteRecoveryZerocloud|TestAccResourceVmcSrmNodeZerocloud|TestAccDataSourceVmcCustomerSubnetsBasic|TestAccDataSourceVmcConnectedAccountsBasic|TestAccDataSourceVmcOrgBasic|TestAccDataSourceVmcSddcBasic|TestAccResourceSddcGroupZerocloud' -parallel 4"
...
...
PASS
ok  	github.com/vmware/terraform-provider-vmc/vmc	513.929s

https://github.com/dimitarproynov/terraform-provider-vmc/actions/runs/5077251365/jobs/9120298039

Signed-off-by: Dimitar Proynov <proynovd@vmware.com>