### PR TITLE
Fix TestAccResourceVmcSddcZerocloud and some documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,80 @@
+# Contributing to terraform-provider-vmc
 
-# Contributing to terraform-provider-vmware-cloud
+Before you start working with terraform-provider-vmc please read our Developer Certificate
+of Origin. All contributions to this repository must be signed as described on
+that page. Your signature certifies that you wrote the patch or have the right
+to pass it on as an open-source patch
 
-The terraform-provider-vmware-cloud project team welcomes contributions from the community. If you wish to contribute code and you have not signed our contributor license agreement (CLA), our bot will update the issue when you open a Pull Request. 
-For any questions about the CLA process, please refer to our [FAQ](https://cla.vmware.com/faq).
+For any questions about the DCO process, please refer to our [FAQ](https://cla.vmware.com/dco).
+
+## Contribution Flow
+
+This is a general outline of what a contributor's workflow looks like:
+
+- Create a topic branch from where you want to base your work
+- Make commits of logical units
+- Make sure your commit messages are in the proper format (see below)
+- Push your changes to a topic branch in your fork of the repository
+- Submit a pull request
+
+Example:
+
+``` shell
+git remote add upstream https://github.com/vmware/terraform-provider-vmc.git
+git checkout -b my-new-feature main
+git commit -a
+git push origin my-new-feature
+```
+
+### Staying In Sync With Upstream
+
+If your branch gets out of sync with the `vmware/main` branch, use the
+following to update:
+
+``` shell
+git checkout my-new-feature
+git fetch -a
+git pull --rebase upstream main
+git push --force-with-lease origin my-new-feature
+```
+
+### Updating Pull Requests
+
+If your pull request fails to pass CI or needs changes based on code review,
+you'll most likely want to squash these changes into existing commits.
+
+If your pull request contains a single commit or your changes are related to
+the most recent commit, you can simply amend the commit.
+
+``` shell
+git add .
+git commit --amend
+git push --force-with-lease origin my-new-feature
+```
+
+If you need to squash changes into an earlier commit, you can use:
+
+``` shell
+git add .
+git commit --fixup <commit>
+git rebase -i --autosquash main
+git push --force-with-lease origin my-new-feature
+```
+
+Be sure to add a comment to the pull request indicating your new changes are
+ready to review. GitHub does not provide a notification for a git push.
+
+### Code Style
+
+### Formatting Commit Messages
+
+We follow the conventions on [How to Write a Git Commit Message](http://chris.beams.io/posts/git-commit/).
+
+Be sure to include any related GitHub issue references in the commit message.
+See [GFM syntax](https://guides.github.com/features/mastering-markdown/#GitHub-flavored-markdown)
+for referencing issues and commits.
 
 ## Reporting Bugs and Creating Issues
 
-Please follow this link  for instructions for creating a pull request from fork [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork).
-
+When opening a new issue, try to roughly follow the commit message format
+conventions above.

--- a/vmc/resource_vmc_sddc_test.go
+++ b/vmc/resource_vmc_sddc_test.go
@@ -215,10 +215,6 @@ resource "vmc_sddc" "sddc_zerocloud" {
     customer_subnet_ids  = [data.vmc_customer_subnets.my_subnets.ids[0]]
     connected_account_id = data.vmc_connected_accounts.my_accounts.id
 	}
-	microsoft_licensing_config {
-        mssql_licensing = "DISABLED"
-        windows_licensing = "ENABLED"
-    }
     timeouts {
       create = "300m"
       update = "300m"


### PR DESCRIPTION
VMC Orgs without connected VMW billing account (like the testing ORG) cannot have microsoft_licensing_config.

Fix CONTRIBUTING.md to align with the project as it uses DCO instead of CLA

Testing done:

=== RUN   TestAccResourceVmcSddcZerocloud
=== PAUSE TestAccResourceVmcSddcZerocloud
=== CONT  TestAccResourceVmcSddcZerocloud
SDDC terraform_sddc_test_dhbipe0lfx created successfully with id 37b4c3fb-360c-43d4-88c9-f3e025f75fe1 
--- PASS: TestAccResourceVmcSddcZerocloud (157.61s)