### PR TITLE
Fixing TestAccResourceVmcClusterZerocloud and TestAccResourceVmcSddcZerocloud

### DIFF
--- a/vmc/resource_vmc_cluster_test.go
+++ b/vmc/resource_vmc_cluster_test.go
@@ -201,18 +201,6 @@ resource "vmc_cluster" "cluster_1" {
 
 func testAccVmcClusterConfigBasicZerocloud(sddcName string, clusterRef string) string {
 	return fmt.Sprintf(`
-
-data "vmc_connected_accounts" "my_accounts" {
-      account_number = %q
-}
-
-data "vmc_customer_subnets" "my_subnets" {
-  connected_account_id = data.vmc_connected_accounts.my_accounts.id
-  region               = "US_WEST_2"
-  sddc_type = "SingleAZ"
-  instance_type = "i3.metal"
-}
-
 resource "vmc_sddc" "sddc_zerocloud_cluster" {
 	sddc_name = %q
 	vpc_cidr      = "10.2.0.0/16"
@@ -225,10 +213,6 @@ resource "vmc_sddc" "sddc_zerocloud_cluster" {
 	skip_creating_vxlan = false
 	sso_domain          = "vmc.local"
 	deployment_type = "SingleAZ"
-    account_link_sddc_config {
-    customer_subnet_ids  = [data.vmc_customer_subnets.my_subnets.ids[0]]
-    connected_account_id = data.vmc_connected_accounts.my_accounts.id
-    }
     timeouts {
       create = "300m"
       update = "300m"
@@ -256,7 +240,6 @@ resource "vmc_cluster" "cluster_2" {
     }
 }
 `,
-		os.Getenv(constants.AwsAccountNumber),
 		sddcName,
 		clusterRef,
 	)

--- a/vmc/resource_vmc_sddc_test.go
+++ b/vmc/resource_vmc_sddc_test.go
@@ -185,17 +185,6 @@ resource "vmc_sddc" "sddc_1" {
 func testAccVmcSddcConfigZerocloud(sddcName string) string {
 	return fmt.Sprintf(`
 
-data "vmc_connected_accounts" "my_accounts" {
-      account_number = %q
-}
-
-data "vmc_customer_subnets" "my_subnets" {
-  connected_account_id = data.vmc_connected_accounts.my_accounts.id
-  region               = "US_WEST_2"
-  sddc_type = "SingleAZ"
-  instance_type = "i3.metal"
-}
-
 resource "vmc_sddc" "sddc_zerocloud" {
 	sddc_name = %q
 	vpc_cidr      = "10.40.0.0/16"
@@ -210,11 +199,7 @@ resource "vmc_sddc" "sddc_zerocloud" {
 	sso_domain          = "vmc.local"
 
 	deployment_type = "SingleAZ"
-	
-	account_link_sddc_config {
-    customer_subnet_ids  = [data.vmc_customer_subnets.my_subnets.ids[0]]
-    connected_account_id = data.vmc_connected_accounts.my_accounts.id
-	}
+
     timeouts {
       create = "300m"
       update = "300m"
@@ -222,7 +207,6 @@ resource "vmc_sddc" "sddc_zerocloud" {
   }
 }
 `,
-		os.Getenv(constants.AwsAccountNumber),
 		sddcName,
 	)
 }


### PR DESCRIPTION

Cannot link account when account linking optional is turned on for org ***. (code)115

=== RUN   TestAccResourceVmcClusterZerocloud
=== PAUSE TestAccResourceVmcClusterZerocloud
=== CONT  TestAccResourceVmcClusterZerocloud
Cluster for SDDC 2f4f7049-c1fd-4bc1-9ed6-1a22efa5a155 created successfully
--- PASS: TestAccResourceVmcClusterZerocloud (508.41s)
PASS

=== RUN   TestAccResourceVmcSddcZerocloud
=== PAUSE TestAccResourceVmcSddcZerocloud
=== CONT  TestAccResourceVmcSddcZerocloud
SDDC terraform_sddc_test_exh0du861m created successfully with id 93a98ae5-97bd-49c1-8de5-7e448fa1cb21
--- PASS: TestAccResourceVmcSddcZerocloud (248.81s)
PASS