### PR TITLE
Fix Failed with Invalid Microsoft Licensing Config

### DIFF
--- a/vmc/resource_vmc_sddc_test.go
+++ b/vmc/resource_vmc_sddc_test.go
@@ -204,7 +204,12 @@ resource "vmc_sddc" "sddc_zerocloud" {
       create = "300m"
       update = "300m"
       delete = "180m"
-  }
+  	}
+
+	microsoft_licensing_config {
+		mssql_licensing = "ENABLED"
+		windows_licensing = "DISABLED"
+	}
 }
 `,
 		sddcName,

--- a/vmc/utils.go
+++ b/vmc/utils.go
@@ -71,7 +71,8 @@ func expandMsftLicenseConfig(config []interface{}) *model.MsftLicensingConfig {
 	licenseConfigMap := config[0].(map[string]interface{})
 	mssqlLicensing := strings.ToUpper(licenseConfigMap["mssql_licensing"].(string))
 	windowsLicensing := strings.ToUpper(licenseConfigMap["windows_licensing"].(string))
-	licenseConfig = model.MsftLicensingConfig{MssqlLicensing: &mssqlLicensing, WindowsLicensing: &windowsLicensing}
+	academicLicense := licenseConfigMap["academic_license"].(bool)
+	licenseConfig = model.MsftLicensingConfig{MssqlLicensing: &mssqlLicensing, WindowsLicensing: &windowsLicensing, AcademicLicense: &academicLicense}
 	return &licenseConfig
 }
 


### PR DESCRIPTION
Fixes #187

Recent change in the backend API made impossible to process microsoft_licensing_config field during sddc deployment.

Moved microsoft_licensing_config setup on post sddc deployment Added microsoft_licensing_config.academic_license field handling

Testing done:
=== RUN   TestAccResourceVmcSddcZerocloud
=== PAUSE TestAccResourceVmcSddcZerocloud
=== CONT  TestAccResourceVmcSddcZerocloud
SDDC terraform_sddc_test_49pbjhxpev created successfully with id a79df99d-9cbc-4da6-b979-a75db3245aad
--- PASS: TestAccResourceVmcSddcZerocloud (120.44s)
PASS
5 times with and without microsoft_licensing_config setting