### PR TITLE
Adding microsoft_licensing_config.academic_license in cluster schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.13.1 (Aug 4, 2023)
+
+BUG FIXES:
+
+* Allowing usage of microsoft_license_config upon SDDC creation. Reading microsoft_license_config.academic_license field [\#190](https://github.com/vmware/terraform-provider-vmc/pull/190)
+
+ENHANCEMENT:
+* Bump google.golang.org/grpc from 1.51.0 to 1.53.0 [\#184](https://github.com/vmware/terraform-provider-vmc/pull/184)
+* Updates to documentation [\#186](https://github.com/vmware/terraform-provider-vmc/pull/186)
+
 ## 1.13 (Feb 23, 2023)
 
 FEATURES:

--- a/vmc/resource_vmc_cluster.go
+++ b/vmc/resource_vmc_cluster.go
@@ -159,6 +159,11 @@ func clusterSchema() map[string]*schema.Schema {
 						ValidateFunc: validation.StringInSlice([]string{
 							constants.LicenseConfigEnabled, constants.LicenseConfigDisabled, constants.CapitalLicenseConfigEnabled, constants.CapitalLicenseConfigDisabled}, false),
 					},
+					"academic_license": {
+						Type:        schema.TypeBool,
+						Optional:    true,
+						Description: "Flag to identify if it is Academic Standard or Commercial Standard License.",
+					},
 				},
 			},
 			Optional:    true,


### PR DESCRIPTION
Recently added changes to handle microsoft_licensing_config.academic_license when populating MsftLicensingConfig field caused acceptance tests failures https://github.com/vmware/terraform-provider-vmc/actions/runs/5751880292/job/15591615714

It occured that the MsftLicensingConfig is present in the cluster schema but the academic_license property is not handled which is causing panic due to panic: interface conversion: interface {} is nil, not bool

Added microsoft_licensing_config.academic_license in cluster schema to fix the issue

Verrified by running TestAccResourceVmcClusterZerocloud
=== RUN   TestAccResourceVmcClusterZerocloud
=== PAUSE TestAccResourceVmcClusterZerocloud
=== CONT  TestAccResourceVmcClusterZerocloud
Cluster for SDDC f4ef91e1-49dd-48a6-abd2-47d9d468292d created successfully
--- PASS: TestAccResourceVmcClusterZerocloud (491.40s)
PASS