### PR TITLE
Fix Failed to read Customer Subnets

### DIFF
--- a/.github/workflows/acceptance_tests_lite.yaml
+++ b/.github/workflows/acceptance_tests_lite.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           terraform_version: ${{ matrix.terraform-version }}
           terraform_wrapper: false
-      - run: make testacc TESTARGS="-run='TestAccResourceVmcSddcZerocloud|TestAccResourceVmcClusterZerocloud|TestAccResourceVmcSiteRecoveryZerocloud|TestAccResourceVmcSrmNodeZerocloud|TestAccDataSourceVmcCustomerSubnetsBasic|TestAccDataSourceVmcConnectedAccountsBasic|TestAccDataSourceVmcOrgBasic|TestAccDataSourceVmcSddcBasic|TestAccResourceSddcGroupZerocloud' -parallel 4"
+      - run: make testacc TESTARGS="-run='TestAccResourceVmcSddcZerocloud|TestAccResourceVmcClusterZerocloud|TestAccResourceVmcSiteRecoveryZerocloud|TestAccResourceVmcSrmNodeZerocloud|TestAccDataSourceVmcCustomerSubnetsBasic|TestAccDataSourceVmcCustomerSubnetsOnlyRequiredProperties|TestAccDataSourceVmcConnectedAccountsBasic|TestAccDataSourceVmcOrgBasic|TestAccDataSourceVmcSddcBasic|TestAccResourceSddcGroupZerocloud' -parallel 4"
         env:
           TF_ACC: '1'
           CLIENT_ID: ${{ secrets.CLIENT_ID }}

--- a/vmc/data_source_vmc_customer_subnets.go
+++ b/vmc/data_source_vmc_customer_subnets.go
@@ -86,13 +86,32 @@ func dataSourceVmcCustomerSubnetsRead(d *schema.ResourceData, m interface{}) err
 	sddcID := d.Get("sddc_id").(string)
 	region := d.Get("region").(string)
 	numHosts := int64(d.Get("num_hosts").(int))
-	sddcType := d.Get("sddc_type").(string)
+
+	/**
+	Fixes https://github.com/vmware/terraform-provider-vmc/issues/191
+	Empty string optional parameters are sent to the API and are failing validation
+	*/
+	var sddcType *string
+	if len(d.Get("sddc_type").(string)) > 0 {
+		tempSddcType := d.Get("sddc_type").(string)
+		sddcType = &tempSddcType
+	}
+
+	/**
+	Fixes https://github.com/vmware/terraform-provider-vmc/issues/191
+	Empty string optional parameters are sent to the API and are failing validation
+	*/
+	var instanceType *string
+	if len(d.Get("instance_type").(string)) > 0 {
+		tempInstanceType := d.Get("instance_type").(string)
+		instanceType = &tempInstanceType
+	}
+
 	forceRefresh := d.Get("force_refresh").(bool)
-	instanceType := d.Get("instance_type").(string)
 
 	connectorWrapper := (m.(*connector.Wrapper)).Connector
 	compatibleSubnetsClient := account_link.NewCompatibleSubnetsClient(connectorWrapper)
-	compatibleSubnets, err := compatibleSubnetsClient.Get(orgID, accountID, &region, &sddcID, &forceRefresh, &instanceType, &sddcType, &numHosts)
+	compatibleSubnets, err := compatibleSubnetsClient.Get(orgID, accountID, &region, &sddcID, &forceRefresh, instanceType, sddcType, &numHosts)
 	ids := []string{}
 	for _, value := range compatibleSubnets.VpcMap {
 		for _, subnet := range value.Subnets {

--- a/vmc/data_source_vmc_customer_subnets_test.go
+++ b/vmc/data_source_vmc_customer_subnets_test.go
@@ -33,6 +33,28 @@ func TestAccDataSourceVmcCustomerSubnetsBasic(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceVmcCustomerSubnetsOnlyRequiredProperties(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckZerocloud(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVmcCustomerSubnetsOnlyRequiredProperties(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.vmc_customer_subnets.my_subnets", "ids.#", "4"),
+					// The following subnet IDs are tightly coupled to the AWS account number provided for testing.
+					// Since the provisioning of an AWS account incurs costs the hardcoded subnets IDs will have to do.
+					// If this tests fails it was probably ran with a different "AwsAccountNumber" than originally designed.
+					resource.TestCheckResourceAttr("data.vmc_customer_subnets.my_subnets", "ids.0", "subnet-01715c65359792049"),
+					resource.TestCheckResourceAttr("data.vmc_customer_subnets.my_subnets", "ids.1", "subnet-01d62fb7a6ef9ca1b"),
+					resource.TestCheckResourceAttr("data.vmc_customer_subnets.my_subnets", "ids.2", "subnet-0cd7c7fdd15b08b07"),
+					resource.TestCheckResourceAttr("data.vmc_customer_subnets.my_subnets", "ids.3", "subnet-08d5d9dc3aad0383a"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataSourceVmcCustomerSubnetsConfig() string {
 	return fmt.Sprintf(`
 	
@@ -45,6 +67,21 @@ data "vmc_customer_subnets" "my_subnets" {
 	region = "US_WEST_2"
 	sddc_type = "SingleAZ"
 	instance_type = "i3.metal"
+}
+`,
+		os.Getenv(constants.AwsAccountNumber))
+}
+
+func testAccDataSourceVmcCustomerSubnetsOnlyRequiredProperties() string {
+	return fmt.Sprintf(`
+	
+data "vmc_connected_accounts" "my_accounts" {
+    account_number = %q
+}
+
+data "vmc_customer_subnets" "my_subnets" {
+	connected_account_id = data.vmc_connected_accounts.my_accounts.id
+	region = "US_WEST_2"
 }
 `,
 		os.Getenv(constants.AwsAccountNumber))


### PR DESCRIPTION
Fixes #191

The VMC provider was failing to retrieve Customer Subnets if SDDC type and instance type fields which are optional were not provided

Error:
Failed to read Customer Subnets : ["Invalid sddc type specified."; (code)115 ]

Fixed the wrong behavior of the provider, added a e2e test to verify that data for Customer Subnets can be retrieved with the required fields only.

Testing Done:
Successful terraform plan with the hcl provided in the issue and version of the provider with the fix
Successful run of acc tests locally

make testacc TESTARGS="-run='TestAccResourceVmcSddcZerocloud|TestAccResourceVmcClusterZerocloud|TestAccResourceVmcSiteRecoveryZerocloud|TestAccResourceVmcSrmNodeZerocloud|TestAccDataSourceVmcCustomerSubnetsBasic|TestAccDataSourceVmcConnectedAccountsBasic|TestAccDataSourceVmcOrgBasic|TestAccDataSourceVmcSddcBasic|TestAccResourceSddcGroupZerocloud' -parallel 4" TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run='TestAccResourceVmcSddcZerocloud|TestAccResourceVmcClusterZerocloud|TestAccResourceVmcSiteRecoveryZerocloud|TestAccResourceVmcSrmNodeZerocloud|TestAccDataSourceVmcCustomerSubnetsBasic|TestAccDataSourceVmcConnectedAccountsBasic|TestAccDataSourceVmcOrgBasic|TestAccDataSourceVmcSddcBasic|TestAccResourceSddcGroupZerocloud' -parallel 4 -timeout 240m
?       github.com/vmware/terraform-provider-vmc        [no test files]
?       github.com/vmware/terraform-provider-vmc/vmc/connector  [no test files]
?       github.com/vmware/terraform-provider-vmc/vmc/constants  [no test files]
=== RUN   TestAccDataSourceVmcConnectedAccountsBasic
--- PASS: TestAccDataSourceVmcConnectedAccountsBasic (4.79s)
=== RUN   TestAccDataSourceVmcCustomerSubnetsBasic
=== PAUSE TestAccDataSourceVmcCustomerSubnetsBasic
=== RUN   TestAccDataSourceVmcOrgBasic
--- PASS: TestAccDataSourceVmcOrgBasic (3.86s)
=== RUN   TestAccDataSourceVmcSddcBasic
--- PASS: TestAccDataSourceVmcSddcBasic (4.54s)
=== RUN   TestAccResourceVmcClusterZerocloud
=== PAUSE TestAccResourceVmcClusterZerocloud
=== RUN   TestAccResourceSddcGroupZerocloud
=== PAUSE TestAccResourceSddcGroupZerocloud
=== RUN   TestAccResourceVmcSddcZerocloud
=== PAUSE TestAccResourceVmcSddcZerocloud
=== RUN   TestAccResourceVmcSiteRecoveryZerocloud
=== PAUSE TestAccResourceVmcSiteRecoveryZerocloud
=== RUN   TestAccResourceVmcSrmNodeZerocloud
=== PAUSE TestAccResourceVmcSrmNodeZerocloud
=== CONT  TestAccDataSourceVmcCustomerSubnetsBasic
=== CONT  TestAccResourceVmcSddcZerocloud
=== CONT  TestAccResourceSddcGroupZerocloud
=== CONT  TestAccResourceVmcClusterZerocloud
--- PASS: TestAccDataSourceVmcCustomerSubnetsBasic (12.64s)
=== CONT  TestAccResourceVmcSrmNodeZerocloud
SDDC terraform_sddc_test_1uhyzid7h1 created successfully with id 8666d6d9-28ec-446b-8d14-f7237c83a8c0
--- PASS: TestAccResourceVmcSddcZerocloud (129.60s)
=== CONT  TestAccResourceVmcSiteRecoveryZerocloud
--- PASS: TestAccResourceSddcGroupZerocloud (177.85s)
Cluster for SDDC 00e87d17-1475-4c28-a34b-01d024845ae4 created successfully
--- PASS: TestAccResourceVmcSrmNodeZerocloud (279.83s)
--- PASS: TestAccResourceVmcSiteRecoveryZerocloud (218.82s)
--- PASS: TestAccResourceVmcClusterZerocloud (482.47s)
PASS
ok      github.com/vmware/terraform-provider-vmc/vmc    496.156s
testing: warning: no tests to run
PASS
ok      github.com/vmware/terraform-provider-vmc/vmc/sddcgroup  (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/vmware/terraform-provider-vmc/vmc/task       (cached) [no tests to run]