### PR TITLE
 Review optional field treated as required

### DIFF
--- a/.github/workflows/acceptance_tests_lite.yaml
+++ b/.github/workflows/acceptance_tests_lite.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           terraform_version: ${{ matrix.terraform-version }}
           terraform_wrapper: false
-      - run: make testacc TESTARGS="-run='TestAccResourceVmcSddcZerocloud|TestAccResourceVmcClusterZerocloud|TestAccResourceVmcSiteRecoveryZerocloud|TestAccResourceVmcSrmNodeZerocloud|TestAccDataSourceVmcCustomerSubnetsBasic|TestAccDataSourceVmcCustomerSubnetsOnlyRequiredProperties|TestAccDataSourceVmcConnectedAccountsBasic|TestAccDataSourceVmcOrgBasic|TestAccDataSourceVmcSddcBasic|TestAccResourceSddcGroupZerocloud' -parallel 4"
+      - run: make testacc TESTARGS="-run='TestAccResourceVmcSddcRequiredFieldsOnlyZerocloud|TestAccResourceVmcSddcZerocloud|TestAccResourceVmcClusterZerocloud|TestAccResourceVmcClusterRequiredFieldsZerocloud|TestAccResourceVmcSiteRecoveryZerocloud|TestAccResourceVmcSrmNodeZerocloud|TestAccDataSourceVmcCustomerSubnetsBasic|TestAccDataSourceVmcCustomerSubnetsOnlyRequiredProperties|TestAccDataSourceVmcConnectedAccountsBasic|TestAccDataSourceVmcOrgBasic|TestAccDataSourceVmcSddcBasic|TestAccResourceSddcGroupZerocloud' -parallel 4"
         env:
           TF_ACC: '1'
           CLIENT_ID: ${{ secrets.CLIENT_ID }}

--- a/vmc/resource_vmc_cluster.go
+++ b/vmc/resource_vmc_cluster.go
@@ -439,8 +439,11 @@ func buildClusterConfig(d *schema.ResourceData) (*model.ClusterConfig, error) {
 	numHosts := int64(d.Get("num_hosts").(int))
 	hostCPUCoresCount := int64(d.Get("host_cpu_cores_count").(int))
 
-	hostInstanceType, err := toHostInstanceType(d.Get("host_instance_type").(string))
-	if err != nil {
+	dataHostInstanceType := d.Get("host_instance_type").(string)
+	hostInstanceType, err := toHostInstanceType(dataHostInstanceType)
+	if len(dataHostInstanceType) > 0 && err != nil {
+		// return error only if nonempty host_instance_type is provided
+		// since host_instance_type field is optional in schema
 		return nil, err
 	}
 	var storageCapacityConverted int64

--- a/vmc/resource_vmc_sddc.go
+++ b/vmc/resource_vmc_sddc.go
@@ -815,8 +815,11 @@ func buildAwsSddcConfig(d *schema.ResourceData) (*model.AwsSddcConfig, error) {
 	}
 
 	accountLinkSddcConfig := expandAccountLinkSddcConfig(accountLinkSddcConfigVar)
-	hostInstanceType, err := toHostInstanceType(d.Get("host_instance_type").(string))
-	if err != nil {
+	dataHostInstanceType := d.Get("host_instance_type").(string)
+	hostInstanceType, err := toHostInstanceType(dataHostInstanceType)
+	if len(dataHostInstanceType) > 0 && err != nil {
+		// return error only if nonempty host_instance_type is provided
+		// since host_instance_type field is optional in schema
 		return nil, err
 	}
 

--- a/vmc/resource_vmc_sddc_test.go
+++ b/vmc/resource_vmc_sddc_test.go
@@ -67,6 +67,29 @@ func TestAccResourceVmcSddcZerocloud(t *testing.T) {
 	})
 }
 
+func TestAccResourceVmcSddcRequiredFieldsOnlyZerocloud(t *testing.T) {
+	var sddcResource model.Sddc
+	sddcName := "terraform_sddc_test_" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckZerocloud(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckVmcSddcDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVmcSddcConfigRequiredFieldsZerocloud(sddcName),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckVmcSddcExists("vmc_sddc.sddc_zerocloud", &sddcResource),
+					testCheckSddcAttributes(&sddcResource),
+					resource.TestCheckResourceAttr("vmc_sddc.sddc_zerocloud", "sddc_state", "READY"),
+					resource.TestCheckResourceAttrSet("vmc_sddc.sddc_zerocloud", "vc_url"),
+					resource.TestCheckResourceAttrSet("vmc_sddc.sddc_zerocloud", "cloud_username"),
+					resource.TestCheckResourceAttrSet("vmc_sddc.sddc_zerocloud", "cloud_password"),
+				),
+			},
+		},
+	})
+}
+
 func testCheckVmcSddcExists(name string, sddcResource *model.Sddc) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
@@ -210,6 +233,20 @@ resource "vmc_sddc" "sddc_zerocloud" {
 		mssql_licensing = "ENABLED"
 		windows_licensing = "DISABLED"
 	}
+}
+`,
+		sddcName,
+	)
+}
+
+func testAccVmcSddcConfigRequiredFieldsZerocloud(sddcName string) string {
+	return fmt.Sprintf(`
+
+resource "vmc_sddc" "sddc_zerocloud" {
+	sddc_name = %q
+	num_host  = 2
+	provider_type = "ZEROCLOUD"
+	region = "US_WEST_2"
 }
 `,
 		sddcName,


### PR DESCRIPTION
 Changed host_instance_type handling in sddc and cluster creation.
 If field is omited in HCL configuration the value is not validated
 Added acceptance tests and appended them to the acceptance tests in the
 github workflow config

 Found bug when creating public IPs