### PR TITLE
Fixing error when two or more srm_nodes are created

### DIFF
--- a/.github/workflows/acceptance_tests_lite.yaml
+++ b/.github/workflows/acceptance_tests_lite.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           terraform_version: ${{ matrix.terraform-version }}
           terraform_wrapper: false
-      - run: make testacc TESTARGS="-run='TestAccResourceVmcSddcRequiredFieldsOnlyZerocloud|TestAccResourceVmcSddcZerocloud|TestAccResourceVmcClusterZerocloud|TestAccResourceVmcClusterRequiredFieldsZerocloud|TestAccResourceVmcSiteRecoveryZerocloud|TestAccResourceVmcSrmNodeZerocloud|TestAccDataSourceVmcCustomerSubnetsBasic|TestAccDataSourceVmcCustomerSubnetsOnlyRequiredProperties|TestAccDataSourceVmcConnectedAccountsBasic|TestAccDataSourceVmcOrgBasic|TestAccDataSourceVmcSddcBasic|TestAccResourceSddcGroupZerocloud' -parallel 4"
+      - run: make testacc TESTARGS="-run='TestAccResourceVmcSddcRequiredFieldsOnlyZerocloud|TestAccResourceVmcSddcZerocloud|TestAccResourceVmcClusterZerocloud|TestAccResourceVmcClusterRequiredFieldsZerocloud|TestAccResourceVmcSiteRecoveryZerocloud|TestAccResourceVmcSrmNodeZerocloud|TestAccResourceVmcMultipleSrmNodesZerocloud|TestAccDataSourceVmcCustomerSubnetsBasic|TestAccDataSourceVmcCustomerSubnetsOnlyRequiredProperties|TestAccDataSourceVmcConnectedAccountsBasic|TestAccDataSourceVmcOrgBasic|TestAccDataSourceVmcSddcBasic|TestAccResourceSddcGroupZerocloud' -parallel 4"
         env:
           TF_ACC: '1'
           CLIENT_ID: ${{ secrets.CLIENT_ID }}


### PR DESCRIPTION
Fixes #175

Fixed the issue.
Added e2e test to verify the solution

Testing done ran all e2e tests locally:

=== RUN   TestAccDataSourceVmcConnectedAccountsBasic
--- PASS: TestAccDataSourceVmcConnectedAccountsBasic (5.19s)
=== RUN   TestAccDataSourceVmcCustomerSubnetsBasic
=== PAUSE TestAccDataSourceVmcCustomerSubnetsBasic
=== RUN   TestAccDataSourceVmcCustomerSubnetsOnlyRequiredProperties
=== PAUSE TestAccDataSourceVmcCustomerSubnetsOnlyRequiredProperties
=== RUN   TestAccDataSourceVmcOrgBasic
--- PASS: TestAccDataSourceVmcOrgBasic (4.21s)
=== RUN   TestAccDataSourceVmcSddcBasic
--- PASS: TestAccDataSourceVmcSddcBasic (5.57s)
=== RUN   TestAccResourceVmcClusterZerocloud
=== PAUSE TestAccResourceVmcClusterZerocloud
=== RUN   TestAccResourceSddcGroupZerocloud
=== PAUSE TestAccResourceSddcGroupZerocloud
=== RUN   TestAccResourceVmcSddcZerocloud
=== PAUSE TestAccResourceVmcSddcZerocloud
=== RUN   TestAccResourceVmcSiteRecoveryZerocloud
=== PAUSE TestAccResourceVmcSiteRecoveryZerocloud
=== RUN   TestAccResourceVmcSrmNodeZerocloud
=== PAUSE TestAccResourceVmcSrmNodeZerocloud
=== CONT  TestAccDataSourceVmcCustomerSubnetsBasic
=== CONT  TestAccResourceVmcSddcZerocloud
=== CONT  TestAccResourceVmcClusterZerocloud
=== CONT  TestAccResourceVmcSrmNodeZerocloud
--- PASS: TestAccDataSourceVmcCustomerSubnetsBasic (15.00s)
=== CONT  TestAccDataSourceVmcCustomerSubnetsOnlyRequiredProperties
--- PASS: TestAccDataSourceVmcCustomerSubnetsOnlyRequiredProperties (16.61s)
=== CONT  TestAccResourceVmcSiteRecoveryZerocloud
SDDC terraform_sddc_test_g72f3uhopf created successfully with id 8ed81560-c11c-4a8c-8325-a2ce2773d939
--- PASS: TestAccResourceVmcSddcZerocloud (128.68s)
=== CONT  TestAccResourceSddcGroupZerocloud
Cluster for SDDC 54bf609d-47fa-4952-98b9-4730800202df created successfully
--- PASS: TestAccResourceVmcSiteRecoveryZerocloud (219.72s)
--- PASS: TestAccResourceVmcSrmNodeZerocloud (275.45s)
--- PASS: TestAccResourceSddcGroupZerocloud (208.10s)
--- PASS: TestAccResourceVmcClusterZerocloud (492.13s)
PASS