### PR TITLE
Speciffic name for the cluster resource

### DIFF
--- a/vmc/resource_vmc_cluster_test.go
+++ b/vmc/resource_vmc_cluster_test.go
@@ -79,7 +79,7 @@ func TestAccResourceVmcClusterZerocloud(t *testing.T) {
 
 func TestAccResourceVmcClusterRequiredFieldsZerocloud(t *testing.T) {
 	var sddcResource model.Sddc
-	clusterRef := "cluster_zerocloud"
+	clusterRef := "cluster_rq_fields_zerocloud"
 	resourceName := "vmc_cluster." + clusterRef
 	sddcName := "terraform_cluster_test_" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
After intrioduction of TestAccResourceVmcClusterRequiredFieldsZerocloud test a constant failure of either TestAccResourceVmcClusterRequiredFieldsZerocloud or TestAccResourceVmcClusterZerocloud is observed.

resource_vmc_cluster_test.go:85: Step 2/2 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.

          map[string]string{
        - 	"edrs_policy_type": "cost",
        + 	"edrs_policy_type": "storage-scaleup",
        - 	"enable_edrs":      "false",
        + 	"enable_edrs":      "true",
        - 	"max_hosts":        "0",
        + 	"max_hosts":        "16",
        - 	"min_hosts":        "0",
        + 	"min_hosts":        "2",
          }

or

=== CONT  TestAccResourceVmcClusterZerocloud
    resource_vmc_cluster_test.go:55: Step 2/2 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.

          map[string]string{
        - 	"max_hosts": "16",
        + 	"max_hosts": "0",
        - 	"min_hosts": "2",
        + 	"min_hosts": "0",
          }

After investigation I found out that the ImportStateIdFunc used in both tests is using the same parameter resourceName which IMHO is causing a race condition i.e. one test may get the id of the cluster created by the other test thus changing the cluster ref name for the TestAccResourceVmcClusterRequiredFieldsZerocloud