### PR TITLE
Changing the lock position in resourceSrmNodeDelete

### DIFF
--- a/vmc/resource_vmc_srm_node.go
+++ b/vmc/resource_vmc_srm_node.go
@@ -157,9 +157,9 @@ func resourceSrmNodeDelete(d *schema.ResourceData, m interface{}) error {
 
 	orgID := (m.(*connector.Wrapper)).OrgID
 	sddcID := d.Get("sddc_id").(string)
+	unlockFn := srmNodeCreationLockMutex.Lock(sddcID)
 	srmNodeID := d.Id()
 	srmNodeDeleteTask, err := siteRecoverySrmNodesClient.Delete(orgID, sddcID, srmNodeID)
-	unlockFn := srmNodeCreationLockMutex.Lock(sddcID)
 	if err != nil {
 		return HandleDeleteError("SRM Node", sddcID, err)
 	}


### PR DESCRIPTION
TestAccResourceVmcMultipleSrmNodesZerocloud was failing with

 testing_new.go:82: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: task failed: failed to delete SRM node:
com.vmware.skyscraper.common.BadRequestException: Failed to lock site recovery for sddc id ########

The lock in resourceSrmNodeDelete was after tha actual delete call. Changed the position of the lock to precede the delete call.

Managed to reproduce the failure of TestAccResourceVmcMultipleSrmNodesZerocloud before the change

Testing done:

Ran several times  TestAccResourceVmcMultipleSrmNodesZerocloud locally with success wfter the change