### PR TITLE
Adding nil checks in resource readings

### DIFF
--- a/vmc/resource_vmc_cluster.go
+++ b/vmc/resource_vmc_cluster.go
@@ -253,7 +253,10 @@ func resourceClusterRead(d *schema.ResourceData, m interface{}) error {
 		if clusterConfig.ClusterId == clusterID {
 			cluster["cluster_name"] = *clusterConfig.ClusterName
 			cluster["cluster_state"] = *clusterConfig.ClusterState
-			cluster["host_instance_type"] = *clusterConfig.EsxHostInfo.InstanceType
+			if clusterConfig.EsxHostInfo != nil {
+				cluster["host_instance_type"] = *clusterConfig.EsxHostInfo.InstanceType
+			}
+
 			if clusterConfig.MsftLicenseConfig != nil {
 				if clusterConfig.MsftLicenseConfig.MssqlLicensing != nil {
 					cluster["mssql_licensing"] = *clusterConfig.MsftLicenseConfig.MssqlLicensing

--- a/vmc/resource_vmc_sddc.go
+++ b/vmc/resource_vmc_sddc.go
@@ -455,7 +455,9 @@ func resourceSddcRead(d *schema.ResourceData, m interface{}) error {
 	cluster := map[string]string{}
 	cluster["cluster_name"] = *primaryCluster.ClusterName
 	cluster["cluster_state"] = *primaryCluster.ClusterState
-	cluster["host_instance_type"] = *primaryCluster.EsxHostInfo.InstanceType
+	if primaryCluster.EsxHostInfo != nil {
+		cluster["host_instance_type"] = *primaryCluster.EsxHostInfo.InstanceType
+	}
 	if primaryCluster.MsftLicenseConfig != nil {
 		if primaryCluster.MsftLicenseConfig.MssqlLicensing != nil {
 			cluster["mssql_licensing"] = *primaryCluster.MsftLicenseConfig.MssqlLicensing


### PR DESCRIPTION
Resolves #201
When the provider receives corrupted response a error is raised panic: runtime error: invalid memory address or nil pointer dereference

Testing Done

=== RUN   TestAccResourceVmcSddcZerocloud
=== PAUSE TestAccResourceVmcSddcZerocloud
=== CONT  TestAccResourceVmcSddcZerocloud
SDDC terraform_sddc_test_f39r861twa created successfully with id 8eea82e6-9dcc-4508-88bd-af50c464326a
--- PASS: TestAccResourceVmcSddcZerocloud (154.79s)
PASS

=== RUN   TestAccResourceVmcClusterZerocloud
=== PAUSE TestAccResourceVmcClusterZerocloud
=== CONT  TestAccResourceVmcClusterZerocloud
Cluster for SDDC 7c1a7152-5f1d-4d8a-a61b-ff0ea8ca7884 created successfully
--- PASS: TestAccResourceVmcClusterZerocloud (493.51s)
PASS