### PR TITLE
Fix broken SDDC Group creation

### DIFF
--- a/vmc/sddcgroup/sddc_group_client.go
+++ b/vmc/sddcgroup/sddc_group_client.go
@@ -133,7 +133,7 @@ func (client *ClientImpl) GetSddcGroup(groupID string) (*DeploymentGroup,
 	if err != nil {
 		return group, config, err
 	}
-	getTraitsURL := client.getBaseURL() + fmt.Sprintf("/network/%s/core/network-connectivity-configs/%s/"+
+	getTraitsURL := client.getBaseURL() + fmt.Sprintf("/network/%s/core/network-connectivity-configs/%s"+
 		"?trait=AwsVpcAttachmentsTrait,AwsDirectConnectGatewayAssociationsTrait,"+
 		"AwsNetworkConnectivityTrait,AwsCustomerTransitGatewayAssociationsTrait",
 		client.connector.OrgID, resourceID)
@@ -239,7 +239,7 @@ func (client *ClientImpl) DeleteSddcGroup(groupID string) (taskID string, error 
 
 func (client *ClientImpl) getResourceIDFromGroupID(groupID string) (resourceID string, error error) {
 	getResourceIDURL := client.getBaseURL() + fmt.Sprintf(
-		"/network/%s/core/network-connectivity-configs/?group_id=%s", client.connector.OrgID, groupID)
+		"/network/%s/core/network-connectivity-configs?group_id=%s", client.connector.OrgID, groupID)
 
 	req := client.createNewRequest(http.MethodGet, getResourceIDURL, nil)
 

--- a/vmc/sddcgroup/sddc_group_client_test.go
+++ b/vmc/sddcgroup/sddc_group_client_test.go
@@ -33,7 +33,7 @@ type HTTPClientStub struct {
 func (stub *HTTPClientStub) Do(req *http.Request) (*http.Response, error) {
 	// Handle getResourceIDFromGroupID preliminary request where resource ID is derived from provided group ID
 	if strings.HasPrefix(req.URL.String(),
-		"https://test.vmc.vmware.com/api/network/testOrgID/core/network-connectivity-configs/?group_id=") {
+		"https://test.vmc.vmware.com/api/network/testOrgID/core/network-connectivity-configs?group_id=") {
 		return &http.Response{
 			StatusCode: 200,
 			Body:       io.NopCloser(strings.NewReader(stub.additionalResourceIDRequestJSON)),
@@ -41,7 +41,7 @@ func (stub *HTTPClientStub) Do(req *http.Request) (*http.Response, error) {
 	}
 	// Handle second request where traits are derived from provided resource ID
 	if strings.HasPrefix(req.URL.String(),
-		"https://test.vmc.vmware.com/api/network/testOrgID/core/network-connectivity-configs/resourceIdDifferentFromGroupId/?trait=") {
+		"https://test.vmc.vmware.com/api/network/testOrgID/core/network-connectivity-configs/resourceIdDifferentFromGroupId?trait=") {
 		return &http.Response{
 			StatusCode: 200,
 			Body:       io.NopCloser(strings.NewReader(stub.additionalResourceTraitsResponseJSON)),


### PR DESCRIPTION
Fixes #208

- Removed trailing slashes from 2 usages of `core/network-connectivity-configs` API endpoint
- Fixed unit test

Testing done:
- verified that TestAccResourceSddcGroupZerocloud is passing localy vasila@vasila2VDJN terraform-provider-vmc % make testacc TESTARGS="-run='TestAccResourceSddcGroupZerocloud'" TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run='TestAccResourceSddcGroupZerocloud' -timeout 240m
?       github.com/vmware/terraform-provider-vmc        [no test files]
?       github.com/vmware/terraform-provider-vmc/vmc/connector  [no test files]
?       github.com/vmware/terraform-provider-vmc/vmc/constants  [no test files]
=== RUN   TestAccResourceSddcGroupZerocloud
=== PAUSE TestAccResourceSddcGroupZerocloud
=== CONT  TestAccResourceSddcGroupZerocloud
--- PASS: TestAccResourceSddcGroupZerocloud (143.74s)
PASS
ok      github.com/vmware/terraform-provider-vmc/vmc    144.186s
testing: warning: no tests to run
PASS
ok      github.com/vmware/terraform-provider-vmc/vmc/sddcgroup  (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/vmware/terraform-provider-vmc/vmc/task       (cached) [no tests to run]

- make build
- golangci-lint run
- varified that client unit test passes

vasila@vasila2VDJN vmc % go test -run 'TestValidateCreateSddcGroup' testing: warning: no tests to run
PASS
ok      github.com/vmware/terraform-provider-vmc/vmc    0.393s