### PR TITLE
Adding diskless host instrance type support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/vmware/vsphere-automation-sdk-go/lib v0.7.0
 	github.com/vmware/vsphere-automation-sdk-go/runtime v0.7.0
 	github.com/vmware/vsphere-automation-sdk-go/services/nsxt-vmc-aws-integration v0.7.0
-	github.com/vmware/vsphere-automation-sdk-go/services/vmc v0.12.0
+	github.com/vmware/vsphere-automation-sdk-go/services/vmc v0.14.0
 	github.com/vmware/vsphere-automation-sdk-go/services/vmc/autoscaler v0.6.0
 	github.com/vmware/vsphere-automation-sdk-go/services/vmc/draas v0.6.0
 	golang.org/x/oauth2 v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -192,6 +192,8 @@ github.com/vmware/vsphere-automation-sdk-go/services/nsxt-vmc-aws-integration v0
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt-vmc-aws-integration v0.7.0/go.mod h1:htCzdCKX+aE4MvPBGYSgbgI9BtJqXTWzKhU6TQtTBlI=
 github.com/vmware/vsphere-automation-sdk-go/services/vmc v0.12.0 h1:qHxs2D5KTB3yc2Ib1YznariK5R3bo0eLyHAtSX5CN3U=
 github.com/vmware/vsphere-automation-sdk-go/services/vmc v0.12.0/go.mod h1:FbObXRbJxdOkI3qu0bzCxdun/bltk83+gOI65rLua3M=
+github.com/vmware/vsphere-automation-sdk-go/services/vmc v0.14.0 h1:h8apaqbHR8c2RAx3OJB1PGDICXrHE37nIEHXXnoAXkc=
+github.com/vmware/vsphere-automation-sdk-go/services/vmc v0.14.0/go.mod h1:FbObXRbJxdOkI3qu0bzCxdun/bltk83+gOI65rLua3M=
 github.com/vmware/vsphere-automation-sdk-go/services/vmc/autoscaler v0.6.0 h1:gQbbzwkv/cJkog6h6gk142kdTXyjv+Xuq+vXlu150B0=
 github.com/vmware/vsphere-automation-sdk-go/services/vmc/autoscaler v0.6.0/go.mod h1:mciXH8XPYdvAHAMGsFXzVlyGtpA5B8DusC11MsBAoPU=
 github.com/vmware/vsphere-automation-sdk-go/services/vmc/draas v0.6.0 h1:/124hmS53PqpmClRJL5H0hQcH5Ok1qBQvOC8a8E6KyA=

--- a/vmc/constants/constants.go
+++ b/vmc/constants/constants.go
@@ -23,6 +23,9 @@ const (
 	HostInstancetypeI3   string = "I3_METAL"
 	HostInstancetypeI3EN string = "I3EN_METAL"
 	HostInstancetypeI4I  string = "I4I_METAL"
+	HostInstancetypeC6I     string = "C6I_METAL"
+	HostInstancetypeM7i24xl string = "M7I_24XL_METAL"
+	HostInstancetypeM7i48xl string = "M7I_48XL_METAL"
 
 	// Availability Zones
 	SingleAvailabilityZone string = "SingleAZ"

--- a/vmc/constants/constants.go
+++ b/vmc/constants/constants.go
@@ -20,9 +20,9 @@ const (
 	SksNSXTManager string = "/sks-nsxt-manager"
 
 	// ESX Host instance types supported for SDDC creation.
-	HostInstancetypeI3   string = "I3_METAL"
-	HostInstancetypeI3EN string = "I3EN_METAL"
-	HostInstancetypeI4I  string = "I4I_METAL"
+	HostInstancetypeI3      string = "I3_METAL"
+	HostInstancetypeI3EN    string = "I3EN_METAL"
+	HostInstancetypeI4I     string = "I4I_METAL"
 	HostInstancetypeC6I     string = "C6I_METAL"
 	HostInstancetypeM7i24xl string = "M7I_24XL_METAL"
 	HostInstancetypeM7i48xl string = "M7I_48XL_METAL"

--- a/vmc/resource_vmc_sddc.go
+++ b/vmc/resource_vmc_sddc.go
@@ -764,9 +764,13 @@ func buildAwsSddcConfig(d *schema.ResourceData) (*model.AwsSddcConfig, error) {
 	}
 	vxlanSubnet := d.Get("vxlan_subnet").(string)
 	delayAccountLink := d.Get("delay_account_link").(bool)
-	accountLinkConfig := &model.AccountLinkConfig{
-		DelayAccountLink: &delayAccountLink,
+	var accountLinkConfig *model.AccountLinkConfig
+	if delayAccountLink {
+		accountLinkConfig = &model.AccountLinkConfig{
+			DelayAccountLink: &delayAccountLink,
+		}
 	}
+
 	providerType := d.Get("provider_type").(string)
 	skipCreatingVxlan := d.Get("skip_creating_vxlan").(bool)
 	ssoDomain := d.Get("sso_domain").(string)
@@ -797,24 +801,29 @@ func buildAwsSddcConfig(d *schema.ResourceData) (*model.AwsSddcConfig, error) {
 		return nil, err
 	}
 
-	return &model.AwsSddcConfig{
+	model := model.AwsSddcConfig{
 		Name:                  sddcName,
 		VpcCidr:               &vpcCidr,
 		NumHosts:              int64(numHost),
 		SddcType:              sddcTypePtr,
 		VxlanSubnet:           &vxlanSubnet,
-		AccountLinkConfig:     accountLinkConfig,
 		Provider:              providerType,
 		SkipCreatingVxlan:     &skipCreatingVxlan,
 		AccountLinkSddcConfig: accountLinkSddcConfig,
 		SsoDomain:             &ssoDomain,
 		SddcTemplateId:        &sddcTemplateID,
 		DeploymentType:        &deploymentType,
-		Region:                region,
+		Region:                &region,
 		HostInstanceType:      &hostInstanceType,
 		Size:                  &sddcSize,
 		MsftLicenseConfig:     nil,
-	}, nil
+	}
+
+	if accountLinkConfig != nil {
+		model.AccountLinkConfig = accountLinkConfig
+	}
+
+	return &model, nil
 }
 
 func expandAccountLinkSddcConfig(l []interface{}) []model.AccountLinkSddcConfig {

--- a/vmc/resource_vmc_sddc.go
+++ b/vmc/resource_vmc_sddc.go
@@ -161,7 +161,7 @@ func sddcSchema() map[string]*schema.Schema {
 			Optional: true,
 			ForceNew: true,
 			ValidateFunc: validation.StringInSlice(
-				[]string{constants.HostInstancetypeI3, constants.HostInstancetypeI3EN, constants.HostInstancetypeI4I}, false),
+				[]string{constants.HostInstancetypeI3, constants.HostInstancetypeI3EN, constants.HostInstancetypeI4I, constants.HostInstancetypeC6I, constants.HostInstancetypeM7i24xl, constants.HostInstancetypeM7i48xl}, false),
 		},
 		"edrs_policy_type": {
 			Type: schema.TypeString,

--- a/vmc/resource_vmc_sddc_test.go
+++ b/vmc/resource_vmc_sddc_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/vmware/terraform-provider-vmc/vmc/connector"
 	"github.com/vmware/terraform-provider-vmc/vmc/constants"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -84,6 +85,54 @@ func TestAccResourceVmcSddcRequiredFieldsOnlyZerocloud(t *testing.T) {
 					resource.TestCheckResourceAttrSet("vmc_sddc.sddc_zerocloud", "vc_url"),
 					resource.TestCheckResourceAttrSet("vmc_sddc.sddc_zerocloud", "cloud_username"),
 					resource.TestCheckResourceAttrSet("vmc_sddc.sddc_zerocloud", "cloud_password"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVmcSddcC6iMetal(t *testing.T) {
+	var sddcResource model.Sddc
+	sddcName := "terraform_sddc_c6i_test_" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckZerocloud(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckVmcSddcDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVmcSddcConfigDiskless(sddcName, constants.HostInstancetypeC6I),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckVmcSddcExists("vmc_sddc.sddc_c6i", &sddcResource),
+					testCheckSddcAttributes(&sddcResource),
+					resource.TestCheckResourceAttr("vmc_sddc.sddc_c6i", "sddc_state", "READY"),
+					resource.TestCheckResourceAttrSet("vmc_sddc.sddc_c6i", "vc_url"),
+					resource.TestCheckResourceAttrSet("vmc_sddc.sddc_c6i", "cloud_username"),
+					resource.TestCheckResourceAttrSet("vmc_sddc.sddc_c6i", "cloud_password"),
+					resource.TestCheckResourceAttrSet("vmc_sddc.sddc_c6i", "nsxt_reverse_proxy_url"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVmcSddcM7i24xlMetal(t *testing.T) {
+	var sddcResource model.Sddc
+	sddcName := "terraform_sddc_m7i_24_xl_test_" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckZerocloud(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckVmcSddcDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVmcSddcConfigDiskless(sddcName, constants.HostInstancetypeM7i24xl),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckVmcSddcExists("vmc_sddc.sddc_c6i", &sddcResource),
+					testCheckSddcAttributes(&sddcResource),
+					resource.TestCheckResourceAttr("vmc_sddc.sddc_sddc_m7i_24xl", "sddc_state", "READY"),
+					resource.TestCheckResourceAttrSet("vmc_sddc.sddc_sddc_m7i_24xl", "vc_url"),
+					resource.TestCheckResourceAttrSet("vmc_sddc.sddc_sddc_m7i_24xl", "cloud_username"),
+					resource.TestCheckResourceAttrSet("vmc_sddc.sddc_sddc_m7i_24xl", "cloud_password"),
+					resource.TestCheckResourceAttrSet("vmc_sddc.sddc_sddc_m7i_24xl", "nsxt_reverse_proxy_url"),
 				),
 			},
 		},
@@ -236,6 +285,56 @@ resource "vmc_sddc" "sddc_zerocloud" {
 }
 `,
 		sddcName,
+	)
+}
+func testAccVmcSddcConfigDiskless(sddcName string, hostInstanceType string) string {
+
+	sddcResourceName := "sddc_" + strings.Replace(strings.ToLower(hostInstanceType), "_metal", "", 1)
+	return fmt.Sprintf(`
+data "vmc_connected_accounts" "my_accounts" {
+  account_number = %q
+}
+
+data "vmc_customer_subnets" "my_subnets" {
+  connected_account_id = data.vmc_connected_accounts.my_accounts.id
+  region               = "US_WEST_2"
+}
+
+resource "vmc_sddc" %q {
+	sddc_name = %q
+	vpc_cidr      = "10.40.0.0/16"
+	num_host      = 3
+	provider_type = "ZEROCLOUD"
+	host_instance_type = %q
+	region = "US_WEST_2"
+	vxlan_subnet = "192.168.1.0/24"
+
+	delay_account_link  = false
+	skip_creating_vxlan = false
+	sso_domain          = "vmc.local"
+
+	deployment_type = "SingleAZ"
+	account_link_sddc_config {
+		customer_subnet_ids  = [data.vmc_customer_subnets.my_subnets.ids[0]]
+		connected_account_id = data.vmc_connected_accounts.my_accounts.id
+	  }
+
+    timeouts {
+      create = "300m"
+      update = "300m"
+      delete = "180m"
+  	}
+
+	microsoft_licensing_config {
+		mssql_licensing = "ENABLED"
+		windows_licensing = "DISABLED"
+	}
+}
+`,
+		os.Getenv(constants.AwsAccountNumber),
+		sddcResourceName,
+		sddcName,
+		hostInstanceType,
 	)
 }
 

--- a/vmc/task/task_convert.go
+++ b/vmc/task/task_convert.go
@@ -54,9 +54,9 @@ func GetAutoscalerTask(connectorWrapper *connector.Wrapper, taskID string) (mode
 	return model.Task{
 		Updated:               autoscalerTask.Updated,
 		UserId:                autoscalerTask.UserId,
-		UpdatedByUserId:       autoscalerTask.UpdatedByUserId,
+		UpdatedByUserId:       &autoscalerTask.UpdatedByUserId,
 		Created:               autoscalerTask.Created,
-		UserName:              autoscalerTask.UserName,
+		UserName:              &autoscalerTask.UserName,
 		Id:                    autoscalerTask.Id,
 		Status:                autoscalerTask.Status,
 		LocalizedErrorMessage: autoscalerTask.ErrorMessage,
@@ -91,9 +91,9 @@ func GetDraasTask(connectorWrapper *connector.Wrapper, taskID string) (model.Tas
 	return model.Task{
 		Updated:               draasTask.Updated,
 		UserId:                draasTask.UserId,
-		UpdatedByUserId:       draasTask.UpdatedByUserId,
+		UpdatedByUserId:       &draasTask.UpdatedByUserId,
 		Created:               draasTask.Created,
-		UserName:              draasTask.UserName,
+		UserName:              &draasTask.UserName,
 		Id:                    draasTask.Id,
 		Status:                draasTask.Status,
 		LocalizedErrorMessage: draasTask.ErrorMessage,

--- a/vmc/utils.go
+++ b/vmc/utils.go
@@ -120,11 +120,11 @@ func toHostInstanceType(userPassedHostInstanceType string) (string, error) {
 	case constants.HostInstancetypeI4I:
 		return model.SddcConfig_HOST_INSTANCE_TYPE_I4I_METAL, nil
 	case constants.HostInstancetypeC6I:
-		return "c6i.metal", nil
+		return model.SddcConfig_HOST_INSTANCE_TYPE_C6I_METAL, nil
 	case constants.HostInstancetypeM7i24xl:
-		return "m7i.metal-24xl", nil
+		return model.SddcConfig_HOST_INSTANCE_TYPE_M7I_METAL_24XL, nil
 	case constants.HostInstancetypeM7i48xl:
-		return "m7i.metal-48xl", nil
+		return model.SddcConfig_HOST_INSTANCE_TYPE_M7I_METAL_48XL, nil
 	default:
 		return "", fmt.Errorf("unknown host instance type: %s", userPassedHostInstanceType)
 	}

--- a/vmc/utils.go
+++ b/vmc/utils.go
@@ -119,6 +119,12 @@ func toHostInstanceType(userPassedHostInstanceType string) (string, error) {
 		return model.SddcConfig_HOST_INSTANCE_TYPE_I3EN_METAL, nil
 	case constants.HostInstancetypeI4I:
 		return model.SddcConfig_HOST_INSTANCE_TYPE_I4I_METAL, nil
+	case constants.HostInstancetypeC6I:
+		return "c6i.metal", nil
+	case constants.HostInstancetypeM7i24xl:
+		return "m7i.metal-24xl", nil
+	case constants.HostInstancetypeM7i48xl:
+		return "m7i.metal-48xl", nil
 	default:
 		return "", fmt.Errorf("unknown host instance type: %s", userPassedHostInstanceType)
 	}


### PR DESCRIPTION

- Updated  vsphere-automation-sdk-go/services/vmc to 0.14.0
- Made changes to support c6i and m7i_24/48 host instances
- Added e2e test for m7i host instances
- Changed the account linking in sddc config to be set only if
  `delay_account_link` is set to true due to failures in environments
where account linking is disabled

Testing done: all e2e passed except currently faling on the pipeline

TestAccResourceVmcSddcM7i24xlMetal passed

API server listening at: 127.0.0.1:60938
=== RUN   TestAccResourceVmcSddcM7i24xlMetal
=== PAUSE TestAccResourceVmcSddcM7i24xlMetal
=== CONT  TestAccResourceVmcSddcM7i24xlMetal
SDDC terraform_sddc_m7i_24_xl_test_62qjki1am8 created successfully with id d8602cbc-bc19-4e80-a8fa-794aeeb04cae
--- PASS: TestAccResourceVmcSddcM7i24xlMetal (138.50s)
PASS

Debugger finished with the exit code 0