### PR TITLE
Diskless instance e2e test changes

### DIFF
--- a/vmc/resource_vmc_sddc.go
+++ b/vmc/resource_vmc_sddc.go
@@ -764,11 +764,9 @@ func buildAwsSddcConfig(d *schema.ResourceData) (*model.AwsSddcConfig, error) {
 	}
 	vxlanSubnet := d.Get("vxlan_subnet").(string)
 	delayAccountLink := d.Get("delay_account_link").(bool)
-	var accountLinkConfig *model.AccountLinkConfig
-	if delayAccountLink {
-		accountLinkConfig = &model.AccountLinkConfig{
-			DelayAccountLink: &delayAccountLink,
-		}
+
+	accountLinkConfig := &model.AccountLinkConfig{
+		DelayAccountLink: &delayAccountLink,
 	}
 
 	providerType := d.Get("provider_type").(string)
@@ -809,6 +807,7 @@ func buildAwsSddcConfig(d *schema.ResourceData) (*model.AwsSddcConfig, error) {
 		VxlanSubnet:           &vxlanSubnet,
 		Provider:              providerType,
 		SkipCreatingVxlan:     &skipCreatingVxlan,
+		AccountLinkConfig:     accountLinkConfig,
 		AccountLinkSddcConfig: accountLinkSddcConfig,
 		SsoDomain:             &ssoDomain,
 		SddcTemplateId:        &sddcTemplateID,
@@ -817,10 +816,6 @@ func buildAwsSddcConfig(d *schema.ResourceData) (*model.AwsSddcConfig, error) {
 		HostInstanceType:      &hostInstanceType,
 		Size:                  &sddcSize,
 		MsftLicenseConfig:     nil,
-	}
-
-	if accountLinkConfig != nil {
-		model.AccountLinkConfig = accountLinkConfig
 	}
 
 	return &model, nil


### PR DESCRIPTION
- Reverted the previously introduced change to add `AwsSddcConfig.AccountLinkSddcConfig` only if `delay_account_linking` set to true due to errors like `Invalid account linking configuration: null`
- Verified that the `m7i.metal-24xl` SDDC can be deployed with account linking config