### PR TITLE
fix: non-constant format string

### DIFF
--- a/vmc/error_handler.go
+++ b/vmc/error_handler.go
@@ -73,7 +73,7 @@ func logVapiErrorData(message string, vAPIMessages []std.LocalizableMessage, vap
 
 	details := fmt.Sprintf(" %s: %s", message, printAPIError(apiError))
 	log.Printf("[ERROR]: %s", details)
-	return fmt.Errorf(details)
+	return fmt.Errorf("%s", details)
 }
 
 func logAPIError(message string, err error) error {

--- a/vmc/sddcgroup/sddc_group_client.go
+++ b/vmc/sddcgroup/sddc_group_client.go
@@ -355,5 +355,5 @@ func toConflictError(rawResponse *[]byte) error {
 	if err != nil {
 		return err
 	}
-	return fmt.Errorf(validationErrorResponseToString(&validationErrorResponse))
+	return fmt.Errorf("%s", validationErrorResponseToString(&validationErrorResponse))
 }


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-vmc/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

This issue was identitied by `golangci-lint run` with `vet` and replaces the non-constant format string in the `fmt.Errorf` call with a constant format string.

```shell
vmc/error_handler.go:76:20: printf: non-constant format string in call to fmt.Errorf (govet)
        return fmt.Errorf(details)
                          ^
vmc/sddcgroup/sddc_group_client.go:358:20: printf: non-constant format string in call to fmt.Errorf (govet)
        return fmt.Errorf(validationErrorResponseToString(&validationErrorResponse))
```

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [x] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
