### PR TITLE
fix: update unused parameters

### DIFF
--- a/vmc/data_source_vmc_customer_subnets.go
+++ b/vmc/data_source_vmc_customer_subnets.go
@@ -33,7 +33,7 @@ func dataSourceVmcCustomerSubnets() *schema.Resource {
 				ValidateFunc: validation.All(
 					validation.NoZeroValues,
 				),
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
 					return old == strings.ReplaceAll(strings.ToUpper(new), "-", "_")
 				},
 			},

--- a/vmc/resource_vmc_cluster.go
+++ b/vmc/resource_vmc_cluster.go
@@ -35,7 +35,7 @@ func resourceCluster() *schema.Resource {
 		Update: resourceClusterUpdate,
 		Read:   resourceClusterRead,
 		Importer: &schema.ResourceImporter{
-			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+			State: func(d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
 				idParts := strings.Split(d.Id(), ",")
 				if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
 					return nil, fmt.Errorf("unexpected format of ID (%q), expected id,sddc_id", d.Id())
@@ -280,7 +280,7 @@ func resourceClusterDelete(d *schema.ResourceData, m interface{}) error {
 				return task.GetTask(connectorWrapper, clusterDeleteTask.Id)
 			},
 			"error deleting cluster "+clusterID,
-			func(task model.Task) {
+			func(_ model.Task) {
 				unlockFunction()
 			})
 		if taskErr != nil {
@@ -328,7 +328,7 @@ func resourceClusterUpdate(d *schema.ResourceData, m interface{}) error {
 					return task.GetTask(connectorWrapper, hostUpdateTask.Id)
 				},
 				"error updating hosts for cluster "+clusterID,
-				func(task model.Task) {
+				func(_ model.Task) {
 					unlockFunction()
 				})
 			if taskErr != nil {
@@ -370,7 +370,7 @@ func resourceClusterUpdate(d *schema.ResourceData, m interface{}) error {
 					return task.GetAutoscalerTask(connectorWrapper, edrsPolicyUpdateTask.Id)
 				},
 				"error updating EDRS policy configuration "+clusterID,
-				func(task model.Task) {
+				func(_ model.Task) {
 					unlockFunction()
 				})
 			if taskErr != nil {
@@ -398,7 +398,7 @@ func resourceClusterUpdate(d *schema.ResourceData, m interface{}) error {
 					return task.GetTask(connectorWrapper, microsoftLicensingUpdateTask.Id)
 				},
 				"error updating Microsoft licensing configuration "+clusterID,
-				func(task model.Task) {
+				func(_ model.Task) {
 					unlockFunction()
 				})
 			if taskErr != nil {

--- a/vmc/resource_vmc_public_ip.go
+++ b/vmc/resource_vmc_public_ip.go
@@ -23,7 +23,7 @@ func resourcePublicIP() *schema.Resource {
 		Update: resourcePublicIPUpdate,
 		Delete: resourcePublicIPDelete,
 		Importer: &schema.ResourceImporter{
-			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+			State: func(d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
 				idParts := strings.Split(d.Id(), ",")
 				if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
 					return nil, fmt.Errorf("unexpected format of ID (%q), expected public_ip_id,nsxt_reverse_proxy_url", d.Id())

--- a/vmc/resource_vmc_sddc.go
+++ b/vmc/resource_vmc_sddc.go
@@ -150,7 +150,7 @@ func sddcSchema() map[string]*schema.Schema {
 			ValidateFunc: validation.All(
 				validation.NoZeroValues,
 			),
-			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+			DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
 				return old == strings.ReplaceAll(strings.ToUpper(new), "-", "_")
 			},
 		},

--- a/vmc/resource_vmc_sddc_test.go
+++ b/vmc/resource_vmc_sddc_test.go
@@ -146,7 +146,7 @@ func testCheckVmcSddcExists(name string, sddcResource *model.Sddc) resource.Test
 }
 
 func testCheckSddcAttributes(sddcResource *model.Sddc) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
+	return func(_ *terraform.State) error {
 		sddcState := sddcResource.SddcState
 		if *sddcState != "READY" {
 			return fmt.Errorf(" SDDC %s with ID %s is not in ready state", *sddcResource.Name, sddcResource.Id)

--- a/vmc/resource_vmc_srm_node.go
+++ b/vmc/resource_vmc_srm_node.go
@@ -32,7 +32,7 @@ func resourceSrmNode() *schema.Resource {
 		Read:   resourceSrmNodeRead,
 		Delete: resourceSrmNodeDelete,
 		Importer: &schema.ResourceImporter{
-			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+			State: func(d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
 				idParts := strings.Split(d.Id(), ",")
 				if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
 					return nil, fmt.Errorf("unexpected format of ID (%q), expected id,sddc_id", d.Id())
@@ -106,7 +106,7 @@ func resourceSrmNodeCreate(d *schema.ResourceData, m interface{}) error {
 				return task.GetDraasTask(connectorWrapper, srmNodeCreateTask.Id)
 			},
 			"error creating SRM node",
-			func(task model.Task) {
+			func(_ model.Task) {
 				unlockFn()
 			})
 		if taskErr != nil {
@@ -171,7 +171,7 @@ func resourceSrmNodeDelete(d *schema.ResourceData, m interface{}) error {
 				return task.GetDraasTask(connectorWrapper, srmNodeDeleteTask.Id)
 			},
 			"failed to delete SRM node",
-			func(task model.Task) {
+			func(_ model.Task) {
 				unlockFn()
 			})
 		if taskErr != nil {

--- a/vmc/task/task_sync_test.go
+++ b/vmc/task/task_sync_test.go
@@ -81,7 +81,7 @@ func TestRetryTaskUntilFinished(t *testing.T) {
 					return model.Task{}, errors.Unauthenticated{}
 				},
 				errorMessage: "",
-				finishCallback: func(task model.Task) {
+				finishCallback: func(_ model.Task) {
 					assert.Fail(t, "finishCallback should not be called on retrievable errors")
 				},
 			},
@@ -111,7 +111,7 @@ func TestRetryTaskUntilFinished(t *testing.T) {
 					return model.Task{}, errors.ServiceUnavailable{}
 				},
 				errorMessage: "",
-				finishCallback: func(task model.Task) {
+				finishCallback: func(_ model.Task) {
 					assert.Fail(t, "finishCallback should not be called on retrievable errors")
 				},
 			},


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-vmc/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Updates unused parameters to `_` so that they are ignored.

Issue seen in `golangci-lint run`.

Example:

```shell
vmc/resource_vmc_cluster.go:331:10: unused-parameter: parameter 'task' seems to be unused, consider removing or renaming it as _ (revive)
                                func(task model.Task) {
                                     ^
vmc/resource_vmc_cluster.go:373:10: unused-parameter: parameter 'task' seems to be unused, consider removing or renaming it as _ (revive)
                                func(task model.Task) {
                                     ^
vmc/resource_vmc_cluster.go:401:10: unused-parameter: parameter 'task' seems to be unused, consider removing or renaming it as _ (revive)
                                func(task model.Task) {
                                     ^
vmc/resource_vmc_sddc.go:153:47: unused-parameter: parameter 'd' seems to be unused, consider removing or renaming it as _ (revive)
                        DiffSuppressFunc: func(_, old, new string, d *schema.ResourceData) bool {
                                                         
```

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [x] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
