### PR TITLE
fix:  use `helper/retry`

### DIFF
--- a/vmc/resource_vmc_cluster.go
+++ b/vmc/resource_vmc_cluster.go
@@ -15,7 +15,7 @@ import (
 	"github.com/vmware/terraform-provider-vmc/vmc/constants"
 	task "github.com/vmware/terraform-provider-vmc/vmc/task"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	autoscalercluster "github.com/vmware/vsphere-automation-sdk-go/services/vmc/autoscaler/api/orgs/sddcs/clusters"
@@ -171,7 +171,7 @@ func resourceClusterCreate(d *schema.ResourceData, m interface{}) error {
 		return HandleCreateError("Cluster", err)
 	}
 	var clusterID = ""
-	return resource.RetryContext(context.Background(), d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+	return retry.RetryContext(context.Background(), d.Timeout(schema.TimeoutCreate), func() *retry.RetryError {
 		taskErr := task.RetryTaskUntilFinished(connectorWrapper,
 			func() (model.Task, error) {
 				return task.GetTask(connectorWrapper, clusterCreateTask.Id)
@@ -189,13 +189,13 @@ func resourceClusterCreate(d *schema.ResourceData, m interface{}) error {
 			return taskErr
 		}
 		if clusterID == "" {
-			return resource.NonRetryableError(fmt.Errorf("error getting clusterID"))
+			return retry.NonRetryableError(fmt.Errorf("error getting clusterID"))
 		}
 		err = resourceClusterRead(d, m)
 		if err == nil {
 			return nil
 		}
-		return resource.NonRetryableError(err)
+		return retry.NonRetryableError(err)
 	})
 }
 
@@ -274,7 +274,7 @@ func resourceClusterDelete(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return HandleDeleteError("Cluster", clusterID, err)
 	}
-	return resource.RetryContext(context.Background(), d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+	return retry.RetryContext(context.Background(), d.Timeout(schema.TimeoutDelete), func() *retry.RetryError {
 		taskErr := task.RetryTaskUntilFinished(connectorWrapper,
 			func() (model.Task, error) {
 				return task.GetTask(connectorWrapper, clusterDeleteTask.Id)
@@ -322,7 +322,7 @@ func resourceClusterUpdate(d *schema.ResourceData, m interface{}) error {
 		if err != nil {
 			return HandleUpdateError("Cluster", err)
 		}
-		err = resource.RetryContext(context.Background(), d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+		err = retry.RetryContext(context.Background(), d.Timeout(schema.TimeoutUpdate), func() *retry.RetryError {
 			taskErr := task.RetryTaskUntilFinished(connectorWrapper,
 				func() (model.Task, error) {
 					return task.GetTask(connectorWrapper, hostUpdateTask.Id)
@@ -338,7 +338,7 @@ func resourceClusterUpdate(d *schema.ResourceData, m interface{}) error {
 			if err == nil {
 				return nil
 			}
-			return resource.NonRetryableError(err)
+			return retry.NonRetryableError(err)
 		})
 		if err != nil {
 			return err
@@ -364,7 +364,7 @@ func resourceClusterUpdate(d *schema.ResourceData, m interface{}) error {
 		if err != nil {
 			return HandleUpdateError("EDRS Policy", err)
 		}
-		return resource.RetryContext(context.Background(), d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+		return retry.RetryContext(context.Background(), d.Timeout(schema.TimeoutUpdate), func() *retry.RetryError {
 			taskErr := task.RetryTaskUntilFinished(connectorWrapper,
 				func() (model.Task, error) {
 					return task.GetAutoscalerTask(connectorWrapper, edrsPolicyUpdateTask.Id)
@@ -380,7 +380,7 @@ func resourceClusterUpdate(d *schema.ResourceData, m interface{}) error {
 			if err == nil {
 				return nil
 			}
-			return resource.NonRetryableError(err)
+			return retry.NonRetryableError(err)
 		})
 	}
 	// Update Microsoft licensing config
@@ -392,7 +392,7 @@ func resourceClusterUpdate(d *schema.ResourceData, m interface{}) error {
 		if err != nil {
 			return HandleUpdateError("Microsoft Licensing Config", err)
 		}
-		return resource.RetryContext(context.Background(), d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		return retry.RetryContext(context.Background(), d.Timeout(schema.TimeoutCreate), func() *retry.RetryError {
 			taskErr := task.RetryTaskUntilFinished(connectorWrapper,
 				func() (model.Task, error) {
 					return task.GetTask(connectorWrapper, microsoftLicensingUpdateTask.Id)
@@ -408,7 +408,7 @@ func resourceClusterUpdate(d *schema.ResourceData, m interface{}) error {
 			if err == nil {
 				return nil
 			}
-			return resource.NonRetryableError(err)
+			return retry.NonRetryableError(err)
 		})
 
 	}

--- a/vmc/resource_vmc_sddc_group.go
+++ b/vmc/resource_vmc_sddc_group.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/vmware/terraform-provider-vmc/vmc/connector"
@@ -189,7 +189,7 @@ func resourceSddcGroupCreate(ctx context.Context, data *schema.ResourceData, i i
 		return diag.FromErr(err)
 	}
 	data.SetId(sddcGroupID)
-	err = resource.RetryContext(context.Background(), data.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+	err = retry.RetryContext(context.Background(), data.Timeout(schema.TimeoutCreate), func() *retry.RetryError {
 		taskErr := task.RetryTaskUntilFinished(connectorWrapper, func() (model.Task, error) {
 			return task.GetV2Task(connectorWrapper, taskID)
 		}, "error creating SDDC group", nil)
@@ -200,7 +200,7 @@ func resourceSddcGroupCreate(ctx context.Context, data *schema.ResourceData, i i
 		if !diags.HasError() {
 			return nil
 		}
-		return resource.NonRetryableError(err)
+		return retry.NonRetryableError(err)
 	})
 	if err != nil {
 		return diag.FromErr(err)
@@ -312,7 +312,7 @@ func resourceSddcGroupDelete(_ context.Context, data *schema.ResourceData, i int
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = resource.RetryContext(context.Background(), data.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+	err = retry.RetryContext(context.Background(), data.Timeout(schema.TimeoutCreate), func() *retry.RetryError {
 		taskErr := task.RetryTaskUntilFinished(connectorWrapper, func() (model.Task, error) {
 			return task.GetV2Task(connectorWrapper, deleteSddcTaskID)
 		}, "error deleting SDDC group", nil)
@@ -341,7 +341,7 @@ func updateSddcGroupMembers(data *schema.ResourceData,
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = resource.RetryContext(context.Background(), data.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+	err = retry.RetryContext(context.Background(), data.Timeout(schema.TimeoutCreate), func() *retry.RetryError {
 		taskErr := task.RetryTaskUntilFinished(connectorWrapper, func() (model.Task, error) {
 			return task.GetV2Task(connectorWrapper, updateMembersTaskID)
 		}, "error updating SDDC group members", nil)

--- a/vmc/resource_vmc_site_recovery.go
+++ b/vmc/resource_vmc_site_recovery.go
@@ -13,9 +13,9 @@ import (
 	"github.com/vmware/terraform-provider-vmc/vmc/connector"
 	task "github.com/vmware/terraform-provider-vmc/vmc/task"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/vmware/vsphere-automation-sdk-go/services/vmc/draas"
 	draasmodel "github.com/vmware/vsphere-automation-sdk-go/services/vmc/draas/model"
@@ -106,7 +106,7 @@ func resourceSiteRecoveryCreate(d *schema.ResourceData, m interface{}) error {
 	// Wait until site recovery is activated
 	taskID := siteRecoveryCreateTask.ResourceId
 	d.SetId(*taskID)
-	return resource.RetryContext(context.Background(), d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+	return retry.RetryContext(context.Background(), d.Timeout(schema.TimeoutCreate), func() *retry.RetryError {
 		taskErr := task.RetryTaskUntilFinished(connectorWrapper,
 			func() (model.Task, error) {
 				return task.GetDraasTask(connectorWrapper, siteRecoveryCreateTask.Id)
@@ -120,7 +120,7 @@ func resourceSiteRecoveryCreate(d *schema.ResourceData, m interface{}) error {
 		if err == nil {
 			return nil
 		}
-		return resource.NonRetryableError(err)
+		return retry.NonRetryableError(err)
 	})
 }
 
@@ -198,7 +198,7 @@ func resourceSiteRecoveryDelete(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return HandleDeleteError("Site recovery", sddcID, err)
 	}
-	return resource.RetryContext(context.Background(), d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+	return retry.RetryContext(context.Background(), d.Timeout(schema.TimeoutDelete), func() *retry.RetryError {
 		taskErr := task.RetryTaskUntilFinished(connectorWrapper,
 			func() (model.Task, error) {
 				return task.GetDraasTask(connectorWrapper, siteRecoveryDeleteTask.Id)

--- a/vmc/resource_vmc_srm_node.go
+++ b/vmc/resource_vmc_srm_node.go
@@ -15,9 +15,9 @@ import (
 	task "github.com/vmware/terraform-provider-vmc/vmc/task"
 	"github.com/vmware/vsphere-automation-sdk-go/services/vmc/model"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/vmware/vsphere-automation-sdk-go/services/vmc/draas"
 	draasmodel "github.com/vmware/vsphere-automation-sdk-go/services/vmc/draas/model"
@@ -100,7 +100,7 @@ func resourceSrmNodeCreate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	d.SetId(*srmNodeCreateTask.ResourceId)
-	return resource.RetryContext(context.Background(), d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+	return retry.RetryContext(context.Background(), d.Timeout(schema.TimeoutCreate), func() *retry.RetryError {
 		taskErr := task.RetryTaskUntilFinished(connectorWrapper,
 			func() (model.Task, error) {
 				return task.GetDraasTask(connectorWrapper, srmNodeCreateTask.Id)
@@ -116,7 +116,7 @@ func resourceSrmNodeCreate(d *schema.ResourceData, m interface{}) error {
 		if err == nil {
 			return nil
 		}
-		return resource.NonRetryableError(err)
+		return retry.NonRetryableError(err)
 	})
 }
 
@@ -165,7 +165,7 @@ func resourceSrmNodeDelete(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return HandleDeleteError("SRM Node", sddcID, err)
 	}
-	return resource.RetryContext(context.Background(), d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+	return retry.RetryContext(context.Background(), d.Timeout(schema.TimeoutDelete), func() *retry.RetryError {
 		taskErr := task.RetryTaskUntilFinished(connectorWrapper,
 			func() (model.Task, error) {
 				return task.GetDraasTask(connectorWrapper, srmNodeDeleteTask.Id)


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-vmc/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

v2.26.0 of `terraform-plugin-sdk` deprecates some types in `helper/resource`, replacing them with equivalents in `helper/id` and `helper/retry`.

Reference: https://github.com/hashicorp/terraform-plugin-sdk/pull/1167.

This pull request replaces the deprecated functions and values from the `terraform-plugin-sdk` `helper/resource` package to `helper/retry`.

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [ ] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
