### PR TITLE
refactor: use `strings.ReplaceAll` for clarity

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,9 +36,6 @@ linters:
       - linters:
           - errcheck
         text: Error return value of `d.Set` is not checked
-      - linters:
-          - staticcheck
-        text: 'QF1004: could use strings.ReplaceAll instead'
     paths:
       - third_party$
       - builtin$

--- a/vmc/utils.go
+++ b/vmc/utils.go
@@ -85,7 +85,7 @@ func getNsxtReverseProxyURLConnector(nsxtReverseProxyURL string, wrapper *connec
 	if wrapper == nil {
 		return nil, fmt.Errorf("nil connector.Wrapper provided")
 	}
-	nsxtReverseProxyURL = strings.Replace(nsxtReverseProxyURL, constants.SksNSXTManager, "", -1)
+	nsxtReverseProxyURL = strings.ReplaceAll(nsxtReverseProxyURL, constants.SksNSXTManager, "")
 	copyWrapper := connector.CopyWrapper(*wrapper)
 	// The wrapper uses the VmcURL as service URL, so setting it to the NSX URL will
 	// force authentication against the NSX instance


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-vmc/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Refactor string replacement to use `strings.ReplaceAll` instead of `strings.Replace` with `n=-1`.

Both functions achieve the same result in this case (replacing all occurrences), but `strings.ReplaceAll` is more explicit about the intent and is generally preferred for readability when all instances are meant to be replaced.

his change also aligns with [`staticcheck` recommendation QF1004](https://staticcheck.dev/docs/checks#QF1004).


**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [x] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [x] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
