### PR TITLE
refactor: use switch statement for scaling logic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,9 +38,6 @@ linters:
         text: Error return value of `d.Set` is not checked
       - linters:
           - staticcheck
-        text: 'QF1003: could use tagged switch on newNum'
-      - linters:
-          - staticcheck
         text: 'QF1004: could use strings.ReplaceAll instead'
     paths:
       - third_party$

--- a/vmc/resource_vmc_sddc.go
+++ b/vmc/resource_vmc_sddc.go
@@ -553,13 +553,14 @@ func resourceSddcUpdate(d *schema.ResourceData, m interface{}) error {
 			_, newTmp := d.GetChange("num_host")
 			newNum := newTmp.(int)
 
-			if newNum == 2 { // 2node SDDC creation
+			switch newNum {
+			case 2: // 2node SDDC creation
 				err := resourceSddcDelete(d, m)
 				if err != nil {
 					return err
 				}
 				return resourceSddcCreate(d, m)
-			} else if newNum == 3 { // 3node SDDC scale up
+			case 3: // 3node SDDC scale up
 				convertClient := sddcs.NewConvertClient(connectorWrapper)
 				sddcTypeUpdateTask, err := convertClient.Create(orgID, sddcID, nil)
 
@@ -582,7 +583,7 @@ func resourceSddcUpdate(d *schema.ResourceData, m interface{}) error {
 				if err != nil {
 					return err
 				}
-			} else {
+			default:
 				return fmt.Errorf("scaling SDDC is not supported. Please check sddc_type and num_host")
 			}
 		}


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-vmc/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Refactor the SDDC scaling logic within resourceSddcUpdate to use a switch statement instead of chained if-else if-else blocks.

This change improves readability and maintainability when handling discrete values of the 'newNum' variable. It makes the different scaling scenarios (2-node recreation, 3-node scale-up) clearer and handles the default unsupported case explicitly.

This also addresses the [`staticcheck` suggestion QF1003](https://staticcheck.dev/docs/checks#QF1003).

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [x] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [ ] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
