### PR TITLE
refactor: redefinition of the built-in functions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,9 +37,6 @@ linters:
           - errcheck
         text: Error return value of `d.Set` is not checked
       - linters:
-          - revive
-        text: 'redefines-builtin-id: redefinition of the built-in'
-      - linters:
           - staticcheck
         text: 'QF1003: could use tagged switch on newNum'
       - linters:

--- a/vmc/data_source_vmc_customer_subnets.go
+++ b/vmc/data_source_vmc_customer_subnets.go
@@ -33,8 +33,8 @@ func dataSourceVmcCustomerSubnets() *schema.Resource {
 				ValidateFunc: validation.All(
 					validation.NoZeroValues,
 				),
-				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
-					return old == strings.ReplaceAll(strings.ToUpper(new), "-", "_")
+				DiffSuppressFunc: func(_, o, n string, _ *schema.ResourceData) bool {
+					return o == strings.ReplaceAll(strings.ToUpper(n), "-", "_")
 				},
 			},
 			"num_hosts": {

--- a/vmc/resource_vmc_sddc.go
+++ b/vmc/resource_vmc_sddc.go
@@ -150,8 +150,8 @@ func sddcSchema() map[string]*schema.Schema {
 			ValidateFunc: validation.All(
 				validation.NoZeroValues,
 			),
-			DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
-				return old == strings.ReplaceAll(strings.ToUpper(new), "-", "_")
+			DiffSuppressFunc: func(_, o, n string, _ *schema.ResourceData) bool {
+				return o == strings.ReplaceAll(strings.ToUpper(n), "-", "_")
 			},
 		},
 		"cluster_id": {

--- a/vmc/task/task_v2_client.go
+++ b/vmc/task/task_v2_client.go
@@ -101,7 +101,7 @@ func (client *V2ClientImpl) getBaseURL() string {
 // executeRequest Returns the body of the response as byte array pointer, the status code
 // or any error that may have occurred during the Http communication.
 func (client *V2ClientImpl) executeRequest(
-	request *http.Request) (responseBody *[]byte, statusCode int, error error) {
+	request *http.Request) (responseBody *[]byte, statusCode int, responseErr error) {
 	response, err := client.HTTPClient.Do(request)
 	defer func(Body io.ReadCloser) {
 		err := Body.Close()


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-vmc/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Fixes the redefinition of the built-in functions.

Before:

```shell
~/Downloads/terraform-provider-vmc git:[refactor/redefinition-of-the-built-in-functions]
golangci-lint run
vmc/data_source_vmc_customer_subnets.go:36:36: redefines-builtin-id: redefinition of the built-in function new (revive)
                                DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
                                                               ^
vmc/resource_vmc_sddc.go:153:35: redefines-builtin-id: redefinition of the built-in function new (revive)
                        DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
                                                       ^
vmc/sddcgroup/sddc_group_client.go:26:59: redefines-builtin-id: redefinition of the built-in type error (revive)
        GetSddcGroup(groupID string) (sddcGroup DeploymentGroup, error error)
                                                                 ^
vmc/sddcgroup/sddc_group_client.go:27:102: redefines-builtin-id: redefinition of the built-in type error (revive)
        CreateSddcGroup(name string, description string, sddcIDs *[]string) (groupID string, taskID string, error error)
                                                                                                            ^
vmc/sddcgroup/sddc_group_client.go:28:108: redefines-builtin-id: redefinition of the built-in type error (revive)
        UpdateSddcGroupMembers(groupID string, sddcIDsToAdd *[]string, sddcIDsToRemove *[]string) (taskID string, error error)
                                                                                                                  ^
vmc/sddcgroup/sddc_group_client.go:29:50: redefines-builtin-id: redefinition of the built-in type error (revive)
        DeleteSddcGroup(groupID string) (taskID string, error error)
                                                        ^
vmc/sddcgroup/sddc_group_client.go:162:53: redefines-builtin-id: redefinition of the built-in type error (revive)
        sddcIDs *[]string) (groupID string, taskID string, error error) {
                                                           ^
vmc/sddcgroup/sddc_group_client.go:202:85: redefines-builtin-id: redefinition of the built-in type error (revive)
        groupID string, sddcIDsToAdd *[]string, sddcIDsToRemove *[]string) (taskID string, error error) {
                                                                                           ^
vmc/sddcgroup/sddc_group_client.go:229:75: redefines-builtin-id: redefinition of the built-in type error (revive)
func (client *ClientImpl) DeleteSddcGroup(groupID string) (taskID string, error error) {
                                                                          ^
vmc/sddcgroup/sddc_group_client.go:243:88: redefines-builtin-id: redefinition of the built-in type error (revive)
func (client *ClientImpl) getResourceIDFromGroupID(groupID string) (resourceID string, error error) {
                                                                                       ^
vmc/sddcgroup/sddc_group_client.go:262:132: redefines-builtin-id: redefinition of the built-in type error (revive)
func (client *ClientImpl) executeNetworkOperation(networkOperation *NetworkOperation) (networkOperationResponse *NetworkOperation, error error) {
                                                                                                                                   ^
vmc/sddcgroup/sddc_group_client.go:300:64: redefines-builtin-id: redefinition of the built-in type error (revive)
        request *http.Request) (responseBody *[]byte, statusCode int, error error) {
                                                                      ^
vmc/task/task_v2_client.go:104:64: redefines-builtin-id: redefinition of the built-in type error (revive)
        request *http.Request) (responseBody *[]byte, statusCode int, error error) {
                                                                      ^
13 issues:
* revive: 13
~/Downloads/te
```

After:

```shell
~/Downloads/terraform-provider-vmc git:[refactor/redefinition-of-the-built-in-functions]
golangci-lint run
0 issues.

~/Downloads/terraform-provider-vmc git:[refactor/use-strings.ReplaceAll]
go fmt ./...

~/Downloads/terraform-provider-vmc git:[refactor/redefinition-of-the-built-in-functions]
make build
==> Checking that code complies with gofmt requirements...
go install
```

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [x] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [ ] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
