### PR TITLE
refactor: simplify type declaration in provider test

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,9 +41,6 @@ linters:
         text: 'redefines-builtin-id: redefinition of the built-in'
       - linters:
           - staticcheck
-        text: 'QF1011: could omit type \*schema.Provider from declaration; it will be inferred from the right-hand side'
-      - linters:
-          - staticcheck
         text: 'QF1003: could use tagged switch on newNum'
       - linters:
           - staticcheck

--- a/vmc/provider_test.go
+++ b/vmc/provider_test.go
@@ -32,7 +32,7 @@ func TestProvider(t *testing.T) {
 }
 
 func TestProvider_impl(_ *testing.T) {
-	var _ *schema.Provider = Provider()
+	var _ = Provider()
 }
 
 func testAccPreCheck(t *testing.T) {


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-vmc/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Refactor the variable declaration in `vmc/provider_test.go` to remove the redundant type `*schema.Provider`. 

The type is inferred from the `Provider()` function call, and omitting it [addresses a `staticcheck` QF1011 warning](https://staticcheck.dev/docs/checks#QF1011) and improves code conciseness.

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [x] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [ ] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
