### PR TITLE
fix: `d.Set` is not checked

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,11 +31,6 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
-    rules:
-      # TODO: Setting temporary exclusions for specific linters.
-      - linters:
-          - errcheck
-        text: Error return value of `d.Set` is not checked
     paths:
       - third_party$
       - builtin$

--- a/vmc/data_source_vmc_customer_subnets.go
+++ b/vmc/data_source_vmc_customer_subnets.go
@@ -126,8 +126,12 @@ func dataSourceVmcCustomerSubnetsRead(d *schema.ResourceData, m interface{}) err
 		return HandleDataSourceReadError("Customer Subnets", err)
 	}
 
-	d.Set("ids", ids)
-	d.Set("customer_available_zones", compatibleSubnets.CustomerAvailableZones)
+	if err := d.Set("ids", ids); err != nil {
+		return err
+	}
+	if err := d.Set("customer_available_zones", compatibleSubnets.CustomerAvailableZones); err != nil {
+		return err
+	}
 	d.SetId(fmt.Sprintf("%s-%s", orgID, accountID))
 	return nil
 }

--- a/vmc/data_source_vmc_org.go
+++ b/vmc/data_source_vmc_org.go
@@ -44,8 +44,12 @@ func dataSourceVmcOrgRead(d *schema.ResourceData, m interface{}) error {
 		return HandleDataSourceReadError("VMC Organization", err)
 	}
 	d.SetId(orgID)
-	d.Set("display_name", org.DisplayName)
-	d.Set("name", org.Name)
+	if err := d.Set("display_name", org.DisplayName); err != nil {
+		return err
+	}
+	if err := d.Set("name", org.Name); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/vmc/data_source_vmc_sddc.go
+++ b/vmc/data_source_vmc_sddc.go
@@ -176,28 +176,61 @@ func dataSourceVmcSddcRead(d *schema.ResourceData, m interface{}) error {
 
 	d.SetId(sddc.Id)
 
-	d.Set("sddc_name", sddc.Name)
-	d.Set("updated", sddc.Updated.String())
-	d.Set("user_id", sddc.UserId)
-	d.Set("updated_by_user_id", sddc.UpdatedByUserId)
-	d.Set("created", sddc.Created.String())
-	d.Set("version", sddc.Version)
-	d.Set("updated_by_user_name", sddc.UpdatedByUserName)
-	d.Set("user_name", sddc.UserName)
-	d.Set("org_id", sddc.OrgId)
-	d.Set("sddc_type", sddc.SddcType)
-	// the key "provider" is reserved by the Terraform SDK, however the same information
-	// is carried by the sddc.ResourceConfig.Provider variable
-	//d.Set("provider", sddc.Provider)
-	d.Set("account_link_state", sddc.AccountLinkState)
-	d.Set("sddc_access_state", sddc.SddcAccessState)
-	d.Set("sddc_type", sddc.SddcType)
-	d.Set("sddc_state", sddc.SddcState)
+	if err := d.Set("sddc_name", sddc.Name); err != nil {
+		return err
+	}
+	if err := d.Set("updated", sddc.Updated.String()); err != nil {
+		return err
+	}
+	if err := d.Set("user_id", sddc.UserId); err != nil {
+		return err
+	}
+	if err := d.Set("updated_by_user_id", sddc.UpdatedByUserId); err != nil {
+		return err
+	}
+	if err := d.Set("created", sddc.Created.String()); err != nil {
+		return err
+	}
+	if err := d.Set("version", sddc.Version); err != nil {
+		return err
+	}
+	if err := d.Set("updated_by_user_name", sddc.UpdatedByUserName); err != nil {
+		return err
+	}
+	if err := d.Set("user_name", sddc.UserName); err != nil {
+		return err
+	}
+	if err := d.Set("org_id", sddc.OrgId); err != nil {
+		return err
+	}
+	if err := d.Set("sddc_type", sddc.SddcType); err != nil {
+		return err
+	}
+	if err := d.Set("account_link_state", sddc.AccountLinkState); err != nil {
+		return err
+	}
+	if err := d.Set("sddc_access_state", sddc.SddcAccessState); err != nil {
+		return err
+	}
+	if err := d.Set("sddc_type", sddc.SddcType); err != nil {
+		return err
+	}
+	if err := d.Set("sddc_state", sddc.SddcState); err != nil {
+		return err
+	}
 	if sddc.ResourceConfig != nil {
-		d.Set("vc_url", sddc.ResourceConfig.VcUrl)
-		d.Set("cloud_username", sddc.ResourceConfig.CloudUsername)
-		d.Set("nsxt_reverse_proxy_url", sddc.ResourceConfig.NsxApiPublicEndpointUrl)
-		d.Set("region", sddc.ResourceConfig.Region)
+		if err := d.Set("vc_url", sddc.ResourceConfig.VcUrl); err != nil {
+			return err
+		}
+		if err := d.Set("cloud_username", sddc.ResourceConfig.CloudUsername); err != nil {
+			return err
+		}
+		if err := d.Set("nsxt_reverse_proxy_url", sddc.ResourceConfig.NsxApiPublicEndpointUrl); err != nil {
+			return err
+		}
+		if err := d.Set("region", sddc.ResourceConfig.Region); err != nil {
+			return err
+		}
 		// Query the API for primary Cluster ID so only it's hosts can be added to the
 		// sddc host
 		primaryClusterClient := sddcs.NewPrimaryclusterClient(connectorWrapper)
@@ -205,25 +238,51 @@ func dataSourceVmcSddcRead(d *schema.ResourceData, m interface{}) error {
 		if err != nil {
 			return HandleReadError(d, "Primary Cluster", sddcID, err)
 		}
-		d.Set("num_host", getHostCountCluster(&sddc, primaryCluster.ClusterId))
-		d.Set("provider_type", sddc.ResourceConfig.Provider)
-		d.Set("availability_zones", sddc.ResourceConfig.AvailabilityZones)
-		d.Set("deployment_type", ConvertDeployType(*sddc.ResourceConfig.DeploymentType))
-		d.Set("sso_domain", *sddc.ResourceConfig.SsoDomain)
-		d.Set("skip_creating_vxlan", *sddc.ResourceConfig.SkipCreatingVxlan)
-		d.Set("nsxt_ui", *sddc.ResourceConfig.Nsxt)
+		if err := d.Set("num_host", getHostCountCluster(&sddc, primaryCluster.ClusterId)); err != nil {
+			return err
+		}
+		if err := d.Set("provider_type", sddc.ResourceConfig.Provider); err != nil {
+			return err
+		}
+		if err := d.Set("availability_zones", sddc.ResourceConfig.AvailabilityZones); err != nil {
+			return err
+		}
+		if err := d.Set("deployment_type", ConvertDeployType(*sddc.ResourceConfig.DeploymentType)); err != nil {
+			return err
+		}
+		if err := d.Set("sso_domain", *sddc.ResourceConfig.SsoDomain); err != nil {
+			return err
+		}
+		if err := d.Set("skip_creating_vxlan", *sddc.ResourceConfig.SkipCreatingVxlan); err != nil {
+			return err
+		}
+		if err := d.Set("nsxt_ui", *sddc.ResourceConfig.Nsxt); err != nil {
+			return err
+		}
 		if sddc.ResourceConfig.NsxCloudAdmin != nil {
-			d.Set("nsxt_cloudadmin", *sddc.ResourceConfig.NsxCloudAdmin)
+			if err := d.Set("nsxt_cloudadmin", *sddc.ResourceConfig.NsxCloudAdmin); err != nil {
+				return err
+			}
 			// Evade nil pointer dereference when user's access_token doesn't have NSX roles
 			if sddc.ResourceConfig.NsxCloudAdminPassword != nil {
-				_ = d.Set("nsxt_cloudadmin_password", *sddc.ResourceConfig.NsxCloudAdminPassword)
+				if err := d.Set("nsxt_cloudadmin_password", *sddc.ResourceConfig.NsxCloudAdminPassword); err != nil {
+					return err
+				}
 			}
 			if sddc.ResourceConfig.NsxCloudAuditPassword != nil {
-				_ = d.Set("nsxt_cloudaudit_password", *sddc.ResourceConfig.NsxCloudAuditPassword)
+				if err := d.Set("nsxt_cloudaudit_password", *sddc.ResourceConfig.NsxCloudAuditPassword); err != nil {
+					return err
+				}
 			}
-			d.Set("nsxt_cloudaudit", *sddc.ResourceConfig.NsxCloudAudit)
-			d.Set("nsxt_private_ip", *sddc.ResourceConfig.NsxMgrManagementIp)
-			d.Set("nsxt_private_url", *sddc.ResourceConfig.NsxMgrLoginUrl)
+			if err := d.Set("nsxt_cloudaudit", *sddc.ResourceConfig.NsxCloudAudit); err != nil {
+				return err
+			}
+			if err := d.Set("nsxt_private_ip", *sddc.ResourceConfig.NsxMgrManagementIp); err != nil {
+				return err
+			}
+			if err := d.Set("nsxt_private_url", *sddc.ResourceConfig.NsxMgrLoginUrl); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/vmc/resource_vmc_cluster.go
+++ b/vmc/resource_vmc_cluster.go
@@ -48,7 +48,9 @@ func resourceCluster() *schema.Resource {
 				}
 
 				d.SetId(idParts[0])
-				d.Set("sddc_id", idParts[1])
+				if err := d.Set("sddc_id", idParts[1]); err != nil {
+					return nil, err
+				}
 				return []*schema.ResourceData{d}, nil
 			},
 		},
@@ -244,8 +246,12 @@ func resourceClusterRead(d *schema.ResourceData, m interface{}) error {
 					cluster["windows_licensing"] = *clusterConfig.MsftLicenseConfig.WindowsLicensing
 				}
 			}
-			d.Set("cluster_info", cluster)
-			d.Set("num_hosts", len(clusterConfig.EsxHostList))
+			if err := d.Set("cluster_info", cluster); err != nil {
+				return err
+			}
+			if err := d.Set("num_hosts", len(clusterConfig.EsxHostList)); err != nil {
+				return err
+			}
 			break
 		}
 	}
@@ -255,10 +261,18 @@ func resourceClusterRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return HandleReadError(d, "Cluster", clusterID, err)
 	}
-	d.Set("edrs_policy_type", *edrsPolicy.PolicyType)
-	d.Set("enable_edrs", edrsPolicy.EnableEdrs)
-	d.Set("max_hosts", *edrsPolicy.MaxHosts)
-	d.Set("min_hosts", *edrsPolicy.MinHosts)
+	if err := d.Set("edrs_policy_type", *edrsPolicy.PolicyType); err != nil {
+		return err
+	}
+	if err := d.Set("enable_edrs", edrsPolicy.EnableEdrs); err != nil {
+		return err
+	}
+	if err := d.Set("max_hosts", *edrsPolicy.MaxHosts); err != nil {
+		return err
+	}
+	if err := d.Set("min_hosts", *edrsPolicy.MinHosts); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/vmc/resource_vmc_public_ip.go
+++ b/vmc/resource_vmc_public_ip.go
@@ -35,7 +35,9 @@ func resourcePublicIP() *schema.Resource {
 					return nil, fmt.Errorf("invalid format for nsxt_reverse_proxy_url : %v", err)
 				}
 				d.SetId(idParts[0])
-				d.Set("nsxt_reverse_proxy_url", idParts[1])
+				if err := d.Set("nsxt_reverse_proxy_url", idParts[1]); err != nil {
+					return nil, err
+				}
 				return []*schema.ResourceData{d}, nil
 			},
 		},
@@ -108,8 +110,12 @@ func resourcePublicIPRead(d *schema.ResourceData, m interface{}) error {
 		if err != nil {
 			return HandleReadError(d, "Public IP", uuid, err)
 		}
-		d.Set("ip", publicIP.Ip)
-		d.Set("display_name", publicIP.DisplayName)
+		if err := d.Set("ip", publicIP.Ip); err != nil {
+			return err
+		}
+		if err := d.Set("display_name", publicIP.DisplayName); err != nil {
+			return err
+		}
 	} else {
 		displayName := d.Get("display_name").(string)
 		if len(displayName) > 0 {
@@ -121,8 +127,12 @@ func resourcePublicIPRead(d *schema.ResourceData, m interface{}) error {
 			publicIpsList := publicIPResultList.Results
 			for _, publicIP := range publicIpsList {
 				if displayName == *publicIP.DisplayName {
-					d.Set("ip", publicIP.Ip)
-					d.Set("display_name", publicIP.DisplayName)
+					if err := d.Set("ip", publicIP.Ip); err != nil {
+						return err
+					}
+					if err := d.Set("display_name", publicIP.DisplayName); err != nil {
+						return err
+					}
 					break
 				}
 			}
@@ -156,7 +166,9 @@ func resourcePublicIPUpdate(d *schema.ResourceData, m interface{}) error {
 			return HandleUpdateError("Public IP", err)
 		}
 
-		d.Set("display_name", publicIP.DisplayName)
+		if err := d.Set("display_name", publicIP.DisplayName); err != nil {
+			return err
+		}
 	}
 
 	return resourcePublicIPRead(d, m)

--- a/vmc/resource_vmc_sddc.go
+++ b/vmc/resource_vmc_sddc.go
@@ -408,30 +408,53 @@ func resourceSddcRead(d *schema.ResourceData, m interface{}) error {
 
 	d.SetId(sddc.Id)
 
-	d.Set("sddc_name", sddc.Name)
-	// The Terraform SDK does not support the use of time.Time type, so save the string
-	// representation
-	d.Set("updated", sddc.Updated.String())
-	d.Set("user_id", sddc.UserId)
-	d.Set("updated_by_user_id", sddc.UpdatedByUserId)
-	d.Set("created", sddc.Created.String())
-	d.Set("version", sddc.Version)
-	d.Set("updated_by_user_name", sddc.UpdatedByUserName)
-	d.Set("user_name", sddc.UserName)
-	d.Set("org_id", sddc.OrgId)
-	d.Set("sddc_type", sddc.SddcType)
-	// the key "provider" is reserved by the Terraform SDK, however the same information
-	// is provided by the sddc.ResourceConfig.Provider variable
-	//d.Set("provider", sddc.Provider)
-	d.Set("account_link_state", sddc.AccountLinkState)
-	d.Set("sddc_access_state", sddc.SddcAccessState)
-	d.Set("sddc_state", sddc.SddcState)
+	if err := d.Set("sddc_name", sddc.Name); err != nil {
+		return err
+	}
+	if err := d.Set("updated", sddc.Updated.String()); err != nil {
+		return err
+	}
+	if err := d.Set("user_id", sddc.UserId); err != nil {
+		return err
+	}
+	if err := d.Set("updated_by_user_id", sddc.UpdatedByUserId); err != nil {
+		return err
+	}
+	if err := d.Set("created", sddc.Created.String()); err != nil {
+		return err
+	}
+	if err := d.Set("version", sddc.Version); err != nil {
+		return err
+	}
+	if err := d.Set("updated_by_user_name", sddc.UpdatedByUserName); err != nil {
+		return err
+	}
+	if err := d.Set("user_name", sddc.UserName); err != nil {
+		return err
+	}
+	if err := d.Set("org_id", sddc.OrgId); err != nil {
+		return err
+	}
+	if err := d.Set("sddc_type", sddc.SddcType); err != nil {
+		return err
+	}
+	if err := d.Set("account_link_state", sddc.AccountLinkState); err != nil {
+		return err
+	}
+	if err := d.Set("sddc_access_state", sddc.SddcAccessState); err != nil {
+		return err
+	}
+	if err := d.Set("sddc_state", sddc.SddcState); err != nil {
+		return err
+	}
 	primaryClusterClient := sddcs.NewPrimaryclusterClient(connectorWrapper.Connector)
 	primaryCluster, err := primaryClusterClient.Get(orgID, sddcID)
 	if err != nil {
 		return HandleReadError(d, "Primary Cluster", sddcID, err)
 	}
-	d.Set("cluster_id", primaryCluster.ClusterId)
+	if err := d.Set("cluster_id", primaryCluster.ClusterId); err != nil {
+		return err
+	}
 	cluster := map[string]string{}
 	cluster["cluster_name"] = *primaryCluster.ClusterName
 	cluster["cluster_state"] = *primaryCluster.ClusterState
@@ -446,44 +469,86 @@ func resourceSddcRead(d *schema.ResourceData, m interface{}) error {
 			cluster["windows_licensing"] = *primaryCluster.MsftLicenseConfig.WindowsLicensing
 		}
 	}
-	d.Set("cluster_info", cluster)
+	if err := d.Set("cluster_info", cluster); err != nil {
+		return err
+	}
 	if sddc.ResourceConfig != nil {
-		d.Set("vc_url", sddc.ResourceConfig.VcUrl)
-		d.Set("cloud_username", sddc.ResourceConfig.CloudUsername)
-		d.Set("cloud_password", sddc.ResourceConfig.CloudPassword)
-		d.Set("nsxt_reverse_proxy_url", sddc.ResourceConfig.NsxApiPublicEndpointUrl)
-		d.Set("region", *sddc.ResourceConfig.Region)
-		d.Set("availability_zones", sddc.ResourceConfig.AvailabilityZones)
-		d.Set("deployment_type", ConvertDeployType(*sddc.ResourceConfig.DeploymentType))
-		d.Set("sso_domain", *sddc.ResourceConfig.SsoDomain)
-		d.Set("skip_creating_vxlan", *sddc.ResourceConfig.SkipCreatingVxlan)
-		d.Set("provider_type", sddc.ResourceConfig.Provider)
+		if err := d.Set("vc_url", sddc.ResourceConfig.VcUrl); err != nil {
+			return err
+		}
+		if err := d.Set("cloud_username", sddc.ResourceConfig.CloudUsername); err != nil {
+			return err
+		}
+		if err := d.Set("cloud_password", sddc.ResourceConfig.CloudPassword); err != nil {
+			return err
+		}
+		if err := d.Set("nsxt_reverse_proxy_url", sddc.ResourceConfig.NsxApiPublicEndpointUrl); err != nil {
+			return err
+		}
+		if err := d.Set("region", *sddc.ResourceConfig.Region); err != nil {
+			return err
+		}
+		if err := d.Set("availability_zones", sddc.ResourceConfig.AvailabilityZones); err != nil {
+			return err
+		}
+		if err := d.Set("deployment_type", ConvertDeployType(*sddc.ResourceConfig.DeploymentType)); err != nil {
+			return err
+		}
+		if err := d.Set("sso_domain", *sddc.ResourceConfig.SsoDomain); err != nil {
+			return err
+		}
+		if err := d.Set("skip_creating_vxlan", *sddc.ResourceConfig.SkipCreatingVxlan); err != nil {
+			return err
+		}
+		if err := d.Set("provider_type", sddc.ResourceConfig.Provider); err != nil {
+			return err
+		}
 		// SDDC's num_host should account for the amount of hosts on its primary cluster only.
 		// Otherwise, there will be no way to scale up or down the primary cluster.
-		d.Set("num_host", getHostCountCluster(&sddc, primaryCluster.ClusterId))
+		if err := d.Set("num_host", getHostCountCluster(&sddc, primaryCluster.ClusterId)); err != nil {
+			return err
+		}
 		if sddc.ResourceConfig.VpcInfo != nil && sddc.ResourceConfig.VpcInfo.VpcCidr != nil {
-			d.Set("vpc_cidr", *sddc.ResourceConfig.VpcInfo.VpcCidr)
+			if err := d.Set("vpc_cidr", *sddc.ResourceConfig.VpcInfo.VpcCidr); err != nil {
+				return err
+			}
 		}
 		skipCreatingVxLan := *sddc.ResourceConfig.SkipCreatingVxlan
 		if !skipCreatingVxLan {
-			d.Set("vxlan_subnet", sddc.ResourceConfig.VxlanSubnet)
+			if err := d.Set("vxlan_subnet", sddc.ResourceConfig.VxlanSubnet); err != nil {
+				return err
+			}
 		}
 		sddcSizeInfo := map[string]string{}
 		sddcSizeInfo["vc_size"] = *sddc.ResourceConfig.SddcSize.VcSize
 		sddcSizeInfo["nsx_size"] = *sddc.ResourceConfig.SddcSize.NsxSize
-		d.Set("sddc_size", sddcSizeInfo)
+		if err := d.Set("sddc_size", sddcSizeInfo); err != nil {
+			return err
+		}
 		if sddc.ResourceConfig.NsxCloudAdmin != nil {
-			d.Set("nsxt_cloudadmin", *sddc.ResourceConfig.NsxCloudAdmin)
+			if err := d.Set("nsxt_cloudadmin", *sddc.ResourceConfig.NsxCloudAdmin); err != nil {
+				return err
+			}
 			// Evade nil pointer dereference when user's access_token doesn't have NSX roles
 			if sddc.ResourceConfig.NsxCloudAdminPassword != nil {
-				_ = d.Set("nsxt_cloudadmin_password", *sddc.ResourceConfig.NsxCloudAdminPassword)
+				if err := d.Set("nsxt_cloudadmin_password", *sddc.ResourceConfig.NsxCloudAdminPassword); err != nil {
+					return err
+				}
 			}
 			if sddc.ResourceConfig.NsxCloudAuditPassword != nil {
-				_ = d.Set("nsxt_cloudaudit_password", *sddc.ResourceConfig.NsxCloudAuditPassword)
+				if err := d.Set("nsxt_cloudaudit_password", *sddc.ResourceConfig.NsxCloudAuditPassword); err != nil {
+					return err
+				}
 			}
-			d.Set("nsxt_cloudaudit", *sddc.ResourceConfig.NsxCloudAudit)
-			d.Set("nsxt_private_ip", *sddc.ResourceConfig.NsxMgrManagementIp)
-			d.Set("nsxt_private_url", *sddc.ResourceConfig.NsxMgrLoginUrl)
+			if err := d.Set("nsxt_cloudaudit", *sddc.ResourceConfig.NsxCloudAudit); err != nil {
+				return err
+			}
+			if err := d.Set("nsxt_private_ip", *sddc.ResourceConfig.NsxMgrManagementIp); err != nil {
+				return err
+			}
+			if err := d.Set("nsxt_private_url", *sddc.ResourceConfig.NsxMgrLoginUrl); err != nil {
+				return err
+			}
 		}
 	}
 	edrsPolicyClient := autoscalercluster.NewEdrsPolicyClient(connectorWrapper.Connector)
@@ -491,10 +556,18 @@ func resourceSddcRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return HandleReadError(d, "SDDC", sddcID, err)
 	}
-	d.Set("edrs_policy_type", *edrsPolicy.PolicyType)
-	d.Set("enable_edrs", edrsPolicy.EnableEdrs)
-	d.Set("max_hosts", *edrsPolicy.MaxHosts)
-	d.Set("min_hosts", *edrsPolicy.MinHosts)
+	if err := d.Set("edrs_policy_type", *edrsPolicy.PolicyType); err != nil {
+		return err
+	}
+	if err := d.Set("enable_edrs", edrsPolicy.EnableEdrs); err != nil {
+		return err
+	}
+	if err := d.Set("max_hosts", *edrsPolicy.MaxHosts); err != nil {
+		return err
+	}
+	if err := d.Set("min_hosts", *edrsPolicy.MinHosts); err != nil {
+		return err
+	}
 
 	if *sddc.Provider != constants.ZeroCloudProviderType {
 		// store intranet_mtu_uplink only for non zerocloud provider types
@@ -508,7 +581,9 @@ func resourceSddcRead(d *schema.ResourceData, m interface{}) error {
 		if err != nil {
 			return HandleReadError(d, "External connectivity configuration", sddcID, err)
 		}
-		d.Set("intranet_mtu_uplink", externalConnectivityConfig.IntranetMtu)
+		if err := d.Set("intranet_mtu_uplink", externalConnectivityConfig.IntranetMtu); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -649,7 +724,9 @@ func resourceSddcUpdate(d *schema.ResourceData, m interface{}) error {
 		if err != nil {
 			return HandleUpdateError("SDDC", err)
 		}
-		d.Set("sddc_name", sddc.Name)
+		if err := d.Set("sddc_name", sddc.Name); err != nil {
+			return err
+		}
 	}
 
 	if d.HasChange("intranet_mtu_uplink") {

--- a/vmc/resource_vmc_site_recovery.go
+++ b/vmc/resource_vmc_site_recovery.go
@@ -134,10 +134,18 @@ func resourceSiteRecoveryRead(d *schema.ResourceData, m interface{}) error {
 		return HandleReadError(d, "Site recovery", sddcID, err)
 	}
 	d.SetId(siteRecovery.Id)
-	d.Set("site_recovery_state", siteRecovery.SiteRecoveryState)
-	d.Set("draas_h5_url", siteRecovery.DraasH5Url)
-	d.Set("user_id", siteRecovery.UserId)
-	d.Set("user_name", siteRecovery.UserName)
+	if err := d.Set("site_recovery_state", siteRecovery.SiteRecoveryState); err != nil {
+		return err
+	}
+	if err := d.Set("draas_h5_url", siteRecovery.DraasH5Url); err != nil {
+		return err
+	}
+	if err := d.Set("user_id", siteRecovery.UserId); err != nil {
+		return err
+	}
+	if err := d.Set("user_name", siteRecovery.UserName); err != nil {
+		return err
+	}
 
 	srmExtensionKey := d.Get("srm_extension_key_suffix").(string)
 	srmNodeMap := map[string]string{}
@@ -180,9 +188,15 @@ func resourceSiteRecoveryRead(d *schema.ResourceData, m interface{}) error {
 	vrNodeMap["type"] = *siteRecovery.VrNode.Type_
 	vrNodeMap["state"] = *siteRecovery.VrNode.State
 	vrNodeMap["ip_address"] = *siteRecovery.VrNode.IpAddress
-	d.Set("sddc_id", *siteRecovery.SddcId)
-	d.Set("srm_node", srmNodeMap)
-	d.Set("vr_node", vrNodeMap)
+	if err := d.Set("sddc_id", *siteRecovery.SddcId); err != nil {
+		return err
+	}
+	if err := d.Set("srm_node", srmNodeMap); err != nil {
+		return err
+	}
+	if err := d.Set("vr_node", vrNodeMap); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/vmc/resource_vmc_srm_node.go
+++ b/vmc/resource_vmc_srm_node.go
@@ -44,7 +44,9 @@ func resourceSrmNode() *schema.Resource {
 				}
 
 				d.SetId(idParts[0])
-				d.Set("sddc_id", idParts[1])
+				if err := d.Set("sddc_id", idParts[1]); err != nil {
+					return nil, err
+				}
 				return []*schema.ResourceData{d}, nil
 			},
 		},
@@ -130,7 +132,9 @@ func resourceSrmNodeRead(d *schema.ResourceData, m interface{}) error {
 		return HandleReadError(d, "SRM Node", sddcID, err)
 	}
 	srmNodeMap := map[string]string{}
-	d.Set("sddc_id", *siteRecovery.SddcId)
+	if err := d.Set("sddc_id", *siteRecovery.SddcId); err != nil {
+		return err
+	}
 	for _, SRMNode := range siteRecovery.SrmNodes {
 		if *SRMNode.Id == srmNodeID {
 			srmNodeMap["id"] = *SRMNode.Id
@@ -144,11 +148,15 @@ func resourceSrmNodeRead(d *schema.ResourceData, m interface{}) error {
 			}
 			hostName := strings.TrimPrefix(*SRMNode.Hostname, constants.SrmPrefix)
 			partStr := strings.Split(hostName, constants.SddcSuffix)
-			d.Set("srm_node_extension_key_suffix", partStr[0])
+			if err := d.Set("srm_node_extension_key_suffix", partStr[0]); err != nil {
+				return err
+			}
 			break
 		}
 	}
-	d.Set("srm_instance", srmNodeMap)
+	if err := d.Set("srm_instance", srmNodeMap); err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-vmc/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

This pull request introduces changes to improve error handling by wrapping `d.Set` calls in error checks across multiple files. Additionally, it removes temporary linter exclusions from the `.golangci.yml` configuration. These changes enhance code robustness and maintainability.

Error Handling Improvements:

* Updated `d.Set` calls in `dataSourceVmcCustomerSubnetsRead`, `dataSourceVmcOrgRead`, and `dataSourceVmcSddcRead` functions to return errors when `d.Set` fails, ensuring better error reporting (`vmc/data_source_vmc_customer_subnets.go`, `vmc/data_source_vmc_org.go`, `vmc/data_source_vmc_sddc.go`). [[1]](diffhunk://#diff-caa198ad18a37ba027f282c65f5c7bcb6e94e1367c6ae95fee39844b4a333666L129-R134) [[2]](diffhunk://#diff-b8a0e64a9866d6d45e54b000a8adb863181a0301065315e8db635c6fa2ac5cb0L47-R52) [[3]](diffhunk://#diff-94c4e8a3a453c6387d925485fd68353403559f8b61e78f27214c419e98ceb348L179-L226)
* Applied similar error handling improvements in resource functions such as `resourceClusterRead`, `resourcePublicIPRead`, `resourceSddcRead`, and `resourceSiteRecoveryRead` to handle `d.Set` errors properly (`vmc/resource_vmc_cluster.go`, `vmc/resource_vmc_public_ip.go`, `vmc/resource_vmc_sddc.go`, `vmc/resource_vmc_site_recovery.go`). [[1]](diffhunk://#diff-25b1013071b0eb393e0e6313f3c1466ae73261808f105792a974e8c661ec3540L247-R254) [[2]](diffhunk://#diff-08544ffa78d7e490e39d57d41455240c54c132d9f1fcc8827fbd15e74e4aaf83L111-R118) [[3]](diffhunk://#diff-2b926944c81066693267c2ae5e56e6ca2fd861d957a0d38ababb41aff3558b71L411-R457) [[4]](diffhunk://#diff-4783b3095c10f7ece9f6657913129bd0f1232795b0621ca5574c118db0c6116bL137-R148)

Configuration Updates:

* Removed temporary linter exclusions for the `errcheck` linter in `.golangci.yml`, which previously ignored unchecked error return values. This aligns with the new error handling improvements. (`.golangci.yml`)

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [x] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [x] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
