### PR TITLE
chore(deps): bump go to v1.26.8

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,10 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
+    rules:
+      - linters:
+          - staticcheck
+        text: 'SA1019: \(github.com/hashicorp/terraform-plugin-(sdk/v2|testing)/'
     paths:
       - third_party$
       - builtin$

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Learn more:
 
     For general information about Terraform, visit [HashiCorp Developer][terraform-install] and [the project][terraform-github] on GitHub.
 
-* [Go 1.26.6][golang-install]
+* [Go 1.26.8][golang-install]
 
     Required, if [building][provider-build] and [testing][provider-test].
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware/terraform-provider-vmc
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/gofrs/uuid/v5 v5.5.1


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-vmc/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Update the Go toolchain requirement from 1.26.6 to 1.26.8.

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [x] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [x] Tests have been completed.
- [x] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
