### PR TITLE
fix: mark vc and nsx passwords as sensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Release History
 
+## 1.15.10
+
+> Release Date: Not Released
+
+SECURITY:
+
+- Mark `cloud_password`, `nsxt_cloudadmin_password`, and `nsxt_cloudaudit_password` as sensitive so
+  `terraform plan` and `terraform show` no longer print SDDC vCenter and NSX administrative
+  passwords. Outputs that reference these attributes are automatically marked sensitive. State is
+  unchanged.
+
+CHORE:
+
+- Updated `go` from 1.26.6 to v1.26.8. [#404](https://github.com/vmware/terraform-provider-vmc/pull/404)
+- Updated `golang.org/x/oauth2` from 0.36.0 to 0.37.0. [#403](https://github.com/vmware/terraform-provider-vmc/pull/403)
+- Updated `google.golang.org/grpc` from 1.82.1 to 1.83.2. [#400](https://github.com/vmware/terraform-provider-vmc/pull/400),
+  [#402](https://github.com/vmware/terraform-provider-vmc/pull/402)
+
 ## 1.15.9
 
 > Release Date: 2026-08-17

--- a/docs/resources/sddc.md
+++ b/docs/resources/sddc.md
@@ -259,6 +259,8 @@ In addition to arguments listed above, the following attributes are exported:
 
 * `nsxt_reverse_proxy_url` - The NSX reverse proxy URL for managing public IP.
 
+* `cloud_password` - The vCenter password for the SDDC cloud user.
+
 * `nsxt_cloudadmin` - The NSX `admin` user for direct access.
 
 * `nsxt_cloudadmin_password` - The NSX `admin` user password for direct access.

--- a/vmc/data_source_vmc_sddc.go
+++ b/vmc/data_source_vmc_sddc.go
@@ -88,16 +88,18 @@ func dataSourceVmcSddc() *schema.Resource {
 				Computed: true,
 			},
 			"nsxt_cloudadmin_password": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 			"nsxt_cloudaudit": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"nsxt_cloudaudit_password": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 			"nsxt_private_ip": {
 				Type:     schema.TypeString,

--- a/vmc/data_source_vmc_sddc_test.go
+++ b/vmc/data_source_vmc_sddc_test.go
@@ -14,6 +14,14 @@ import (
 	"github.com/vmware/terraform-provider-vmc/vmc/constants"
 )
 
+func TestDataSourceSddcPasswordAttributesAreSensitive(t *testing.T) {
+	for _, name := range []string{"nsxt_cloudadmin_password", "nsxt_cloudaudit_password"} {
+		if !dataSourceVmcSddc().Schema[name].Sensitive {
+			t.Errorf("data source vmc_sddc.%s must be Sensitive", name)
+		}
+	}
+}
+
 func TestAccDataSourceVmcSddcBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheckZerocloud(t) },

--- a/vmc/resource_vmc_sddc.go
+++ b/vmc/resource_vmc_sddc.go
@@ -245,8 +245,9 @@ func sddcSchema() map[string]*schema.Schema {
 			Computed: true,
 		},
 		"cloud_password": {
-			Type:     schema.TypeString,
-			Computed: true,
+			Type:      schema.TypeString,
+			Computed:  true,
+			Sensitive: true,
 		},
 		"nsxt_reverse_proxy_url": {
 			Type:     schema.TypeString,
@@ -276,9 +277,10 @@ func sddcSchema() map[string]*schema.Schema {
 			Computed: true,
 		},
 		"nsxt_cloudadmin_password": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
+			Type:      schema.TypeString,
+			Optional:  true,
+			Computed:  true,
+			Sensitive: true,
 		},
 		"nsxt_cloudaudit": {
 			Type:     schema.TypeString,
@@ -286,9 +288,10 @@ func sddcSchema() map[string]*schema.Schema {
 			Computed: true,
 		},
 		"nsxt_cloudaudit_password": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
+			Type:      schema.TypeString,
+			Optional:  true,
+			Computed:  true,
+			Sensitive: true,
 		},
 		"nsxt_private_ip": {
 			Type:     schema.TypeString,

--- a/vmc/resource_vmc_sddc_test.go
+++ b/vmc/resource_vmc_sddc_test.go
@@ -23,6 +23,14 @@ import (
 	"github.com/vmware/terraform-provider-vmc/vmc/constants"
 )
 
+func TestResourceSddcPasswordAttributesAreSensitive(t *testing.T) {
+	for _, name := range []string{"cloud_password", "nsxt_cloudadmin_password", "nsxt_cloudaudit_password"} {
+		if !resourceSddc().Schema[name].Sensitive {
+			t.Errorf("resource vmc_sddc.%s must be Sensitive", name)
+		}
+	}
+}
+
 func TestAccResourceVmcSddc_basic(t *testing.T) {
 	var sddcResource model.Sddc
 	sddcName := "terraform_test_sddc_" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-vmc/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

API-returned vCenter and NSX passwords were printed in `terraform plan` and `show`. Mark `cloud_password`, `nsxt_cloudadmin_password`, and `nsxt_cloudaudit_password` as sensitive so those values are redacted. State is unchanged.

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [x] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
